### PR TITLE
BVTCK-57 Avoid the use of @BeforeMethod

### DIFF
--- a/setup-examples/maven/pom.xml
+++ b/setup-examples/maven/pom.xml
@@ -26,16 +26,10 @@
 
         <container.home>/opt/java/glassfish4</container.home>
 
-        <hv.version>5.3.0-SNAPSHOT</hv.version>
         <validation.provider>org.hibernate.validator.HibernateValidator</validation.provider>
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-validator</artifactId>
-            <version>${hv.version}</version>
-        </dependency>
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>

--- a/setup-examples/readme.md
+++ b/setup-examples/readme.md
@@ -12,9 +12,6 @@ as well as the Bean Validation provider. The latter is the so called Bean Valida
 
 Generally, to adjust the build script to another container, you would have to:
 
-* Replace the Hibernate Validator dependency with the dependency of your provider. Technically the validation
-  provider should not be required on the client side, but due to [BVTCK-57](https://hibernate.atlassian.net/browse/BVTCK-57)
-  it is needed as well.
 * Change the _validation.provider_ property to the fully qualified class name of your Bean Validation provider.
 * Change the Arquillian container adapter dependency to use the adapter suitable for your container
  (see [container adapters](https://docs.jboss.org/author/display/ARQ/Container+adapters)). If there is no such adapter

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/BaseExecutableValidatorTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/BaseExecutableValidatorTest.java
@@ -1,0 +1,25 @@
+/**
+ * Bean Validation TCK
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.beanvalidation.tck.tests;
+
+import javax.validation.executable.ExecutableValidator;
+
+/**
+ * @author Marko Bekhta
+ */
+public abstract class BaseExecutableValidatorTest extends BaseValidatorTest {
+
+	private ExecutableValidator executableValidator;
+
+	protected ExecutableValidator getExecutableValidator() {
+		if ( executableValidator == null ) {
+			executableValidator = getValidator().forExecutables();
+		}
+		return executableValidator;
+	}
+
+}

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/BaseValidatorTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/BaseValidatorTest.java
@@ -1,0 +1,29 @@
+/**
+ * Bean Validation TCK
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.beanvalidation.tck.tests;
+
+import javax.validation.Validator;
+
+import org.hibernate.beanvalidation.tck.util.TestUtil;
+
+import org.jboss.arquillian.testng.Arquillian;
+
+/**
+ * @author Marko Bekhta
+ */
+public abstract class BaseValidatorTest extends Arquillian {
+
+	private Validator validator;
+
+	protected Validator getValidator() {
+		if ( validator == null ) {
+			validator = TestUtil.getValidatorUnderTest();
+		}
+		return validator;
+	}
+
+}

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/application/method/MethodValidationRequirementTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/application/method/MethodValidationRequirementTest.java
@@ -12,42 +12,34 @@ import java.util.Date;
 import java.util.Set;
 import javax.validation.ConstraintViolation;
 import javax.validation.constraints.NotNull;
-import javax.validation.executable.ExecutableValidator;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
 import org.hibernate.beanvalidation.tck.util.TestUtil;
 import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectConstraintTypes;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectNumberOfViolations;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertNodeNames;
+import static org.hibernate.beanvalidation.tck.util.TestUtil.webArchiveBuilder;
 import static org.testng.Assert.assertNotNull;
 
 /**
  * @author Gunnar Morling
  */
 @SpecVersion(spec = "beanvalidation", version = "2.0.0")
-public class MethodValidationRequirementTest extends Arquillian {
-
-	private ExecutableValidator executableValidator;
+public class MethodValidationRequirementTest extends BaseExecutableValidatorTest {
 
 	@Deployment
 	public static WebArchive createTestArchive() {
-		return new WebArchiveBuilder()
+		return webArchiveBuilder()
 				.withTestClassPackage( MethodValidationRequirementTest.class )
 				.build();
-	}
-
-	@BeforeMethod
-	public void setupValidator() {
-		executableValidator = TestUtil.getValidatorUnderTest().forExecutables();
 	}
 
 	@Test
@@ -57,7 +49,7 @@ public class MethodValidationRequirementTest extends Arquillian {
 		Method method = CalendarService.class.getMethod( "setType", String.class );
 		Object[] parameterValues = new Object[1];
 
-		Set<ConstraintViolation<Object>> constraintViolations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -74,7 +66,7 @@ public class MethodValidationRequirementTest extends Arquillian {
 		Constructor<?> constructor = CalendarService.class.getConstructor( String.class );
 		Object[] parameterValues = new Object[1];
 
-		Set<ConstraintViolation<Object>> constraintViolations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
@@ -94,7 +86,7 @@ public class MethodValidationRequirementTest extends Arquillian {
 				new Date( new Date().getTime() - 1000 )
 		};
 
-		Set<ConstraintViolation<Object>> constraintViolations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -114,7 +106,7 @@ public class MethodValidationRequirementTest extends Arquillian {
 				new Date( new Date().getTime() - 1000 )
 		};
 
-		Set<ConstraintViolation<Object>> constraintViolations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
@@ -136,7 +128,7 @@ public class MethodValidationRequirementTest extends Arquillian {
 		);
 		Object[] parameterValues = new Object[3];
 
-		Set<ConstraintViolation<Object>> constraintViolations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -161,7 +153,7 @@ public class MethodValidationRequirementTest extends Arquillian {
 		);
 		Object[] parameterValues = new Object[3];
 
-		Set<ConstraintViolation<Object>> constraintViolations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
@@ -181,7 +173,7 @@ public class MethodValidationRequirementTest extends Arquillian {
 		Method method = CalendarService.class.getMethod( "findEvents", String.class );
 		Object returnValue = null;
 
-		Set<ConstraintViolation<Object>> constraintViolations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
@@ -197,7 +189,7 @@ public class MethodValidationRequirementTest extends Arquillian {
 		Constructor<?> constructor = CalendarService.class.getConstructor();
 		Object returnValue = new CalendarService();
 
-		Set<ConstraintViolation<Object>> constraintViolations = executableValidator.validateConstructorReturnValue(
+		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator().validateConstructorReturnValue(
 				constructor,
 				returnValue
 		);
@@ -213,7 +205,7 @@ public class MethodValidationRequirementTest extends Arquillian {
 		Method method = CalendarEvent.class.getMethod( "setUser", User.class );
 		Object[] parameterValues = new Object[] { new User() };
 
-		Set<ConstraintViolation<Object>> constraintViolations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -235,7 +227,7 @@ public class MethodValidationRequirementTest extends Arquillian {
 		Constructor<?> constructor = CalendarEvent.class.getConstructor( User.class );
 		Object[] parameterValues = new Object[] { new User() };
 
-		Set<ConstraintViolation<Object>> constraintViolations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
@@ -257,7 +249,7 @@ public class MethodValidationRequirementTest extends Arquillian {
 		Method method = CalendarEvent.class.getMethod( "getUser" );
 		Object returnValue = new User();
 
-		Set<ConstraintViolation<Object>> constraintViolations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
@@ -279,7 +271,7 @@ public class MethodValidationRequirementTest extends Arquillian {
 		Constructor<?> constructor = CalendarEvent.class.getConstructor( String.class );
 		Object returnValue = new CalendarEvent( null, null );
 
-		Set<ConstraintViolation<Object>> constraintViolations = executableValidator.validateConstructorReturnValue(
+		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator().validateConstructorReturnValue(
 				constructor,
 				returnValue
 		);
@@ -301,7 +293,7 @@ public class MethodValidationRequirementTest extends Arquillian {
 		Method method = CalendarEvent.class.getMethod( "setUser", User.class );
 		Object[] parameterValues = new Object[1];
 
-		Set<ConstraintViolation<Object>> constraintViolations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -316,7 +308,7 @@ public class MethodValidationRequirementTest extends Arquillian {
 		Constructor<?> constructor = CalendarEvent.class.getConstructor( User.class );
 		Object[] parameterValues = new Object[1];
 
-		Set<ConstraintViolation<Object>> constraintViolations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
@@ -331,7 +323,7 @@ public class MethodValidationRequirementTest extends Arquillian {
 		Method method = CalendarEvent.class.getMethod( "getUser" );
 		Object returnValue = null;
 
-		Set<ConstraintViolation<Object>> constraintViolations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
@@ -347,7 +339,7 @@ public class MethodValidationRequirementTest extends Arquillian {
 		Method method = CalendarEvent.class.getMethod( "setUser", User.class );
 		Object[] parameterValues = new Object[] { new User( new Account() ) };
 
-		Set<ConstraintViolation<Object>> constraintViolations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -370,7 +362,7 @@ public class MethodValidationRequirementTest extends Arquillian {
 		Constructor<?> constructor = CalendarEvent.class.getConstructor( User.class );
 		Object[] parameterValues = new Object[] { new User( new Account() ) };
 
-		Set<ConstraintViolation<Object>> constraintViolations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
@@ -393,7 +385,7 @@ public class MethodValidationRequirementTest extends Arquillian {
 		Method method = CalendarEvent.class.getMethod( "getUser" );
 		Object returnValue = new User( new Account() );
 
-		Set<ConstraintViolation<Object>> constraintViolations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
@@ -416,7 +408,7 @@ public class MethodValidationRequirementTest extends Arquillian {
 		Constructor<?> constructor = CalendarEvent.class.getConstructor( String.class );
 		Object returnValue = new CalendarEvent();
 
-		Set<ConstraintViolation<Object>> constraintViolations = executableValidator.validateConstructorReturnValue(
+		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator().validateConstructorReturnValue(
 				constructor,
 				returnValue
 		);

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/crossparameter/GenericAndCrossParameterConstraintTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/crossparameter/GenericAndCrossParameterConstraintTest.java
@@ -11,45 +11,33 @@ import java.util.Date;
 import java.util.Set;
 import javax.validation.ConstraintTarget;
 import javax.validation.ConstraintViolation;
-import javax.validation.Validator;
-import javax.validation.executable.ExecutableValidator;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import org.hibernate.beanvalidation.tck.util.TestUtil;
+import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
 import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectConstraintTypes;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.TestUtil.webArchiveBuilder;
 import static org.testng.Assert.assertEquals;
 
 /**
  * @author Gunnar Morling
  */
 @SpecVersion(spec = "beanvalidation", version = "2.0.0")
-public class GenericAndCrossParameterConstraintTest extends Arquillian {
-
-	private Validator validator;
-	private ExecutableValidator executableValidator;
+public class GenericAndCrossParameterConstraintTest extends BaseExecutableValidatorTest {
 
 	@Deployment
 	public static WebArchive createTestArchive() {
-		return new WebArchiveBuilder()
+		return webArchiveBuilder()
 				.withTestClassPackage( GenericAndCrossParameterConstraintTest.class )
 				.build();
-	}
-
-	@BeforeMethod
-	public void setupValidator() {
-		validator = TestUtil.getValidatorUnderTest();
-		executableValidator = validator.forExecutables();
 	}
 
 	@Test
@@ -63,14 +51,14 @@ public class GenericAndCrossParameterConstraintTest extends Arquillian {
 		Object[] parameterValues = new Object[2];
 		Object returnValue = new Object();
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
 		);
 		assertCorrectNumberOfViolations( violations, 0 );
 
-		violations = executableValidator.validateReturnValue( object, method, returnValue );
+		violations = getExecutableValidator().validateReturnValue( object, method, returnValue );
 		assertCorrectNumberOfViolations( violations, 1 );
 		assertCorrectConstraintTypes( violations, GenericConstraint.class );
 		assertEquals( violations.iterator().next().getInvalidValue(), returnValue );
@@ -84,14 +72,14 @@ public class GenericAndCrossParameterConstraintTest extends Arquillian {
 		Object[] parameterValues = new Object[2];
 		Object returnValue = new Object();
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
 		);
 		assertCorrectNumberOfViolations( violations, 0 );
 
-		violations = executableValidator.validateReturnValue( object, method, returnValue );
+		violations = getExecutableValidator().validateReturnValue( object, method, returnValue );
 		assertCorrectNumberOfViolations( violations, 1 );
 		assertCorrectConstraintTypes( violations, ExplicitGenericConstraint.class );
 		assertEquals( violations.iterator().next().getInvalidValue(), returnValue );
@@ -105,14 +93,14 @@ public class GenericAndCrossParameterConstraintTest extends Arquillian {
 		Object[] parameterValues = new Object[2];
 		Object returnValue = new Object();
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
 		);
 		assertCorrectNumberOfViolations( violations, 0 );
 
-		violations = executableValidator.validateParameters( object, method, parameterValues );
+		violations = getExecutableValidator().validateParameters( object, method, parameterValues );
 		assertCorrectNumberOfViolations( violations, 1 );
 		assertCorrectConstraintTypes( violations, CrossParameterConstraint.class );
 		assertEquals( violations.iterator().next().getInvalidValue(), parameterValues );
@@ -131,14 +119,14 @@ public class GenericAndCrossParameterConstraintTest extends Arquillian {
 		Object returnValue = new Object();
 
 		//constraint applies to return value
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
 		);
 		assertCorrectNumberOfViolations( violations, 0 );
 
-		violations = executableValidator.validateReturnValue( object, method, returnValue );
+		violations = getExecutableValidator().validateReturnValue( object, method, returnValue );
 		assertCorrectNumberOfViolations( violations, 1 );
 		assertCorrectConstraintTypes( violations, GenericAndCrossParameterConstraintWithOneValidator.class );
 		assertEquals( violations.iterator().next().getInvalidValue(), returnValue );
@@ -146,10 +134,10 @@ public class GenericAndCrossParameterConstraintTest extends Arquillian {
 		method = MobileCalendar.class.getMethod( "addEvent", Date.class, Date.class );
 
 		//constraint applies to parameters
-		violations = executableValidator.validateReturnValue( object, method, returnValue );
+		violations = getExecutableValidator().validateReturnValue( object, method, returnValue );
 		assertCorrectNumberOfViolations( violations, 0 );
 
-		violations = executableValidator.validateParameters( object, method, parameterValues );
+		violations = getExecutableValidator().validateParameters( object, method, parameterValues );
 		assertCorrectNumberOfViolations( violations, 1 );
 		assertCorrectConstraintTypes( violations, GenericAndCrossParameterConstraintWithOneValidator.class );
 		assertEquals( violations.iterator().next().getInvalidValue(), parameterValues );

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/crossparameter/InvalidDeclarationOfGenericAndCrossParameterConstraintTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/crossparameter/InvalidDeclarationOfGenericAndCrossParameterConstraintTest.java
@@ -11,43 +11,31 @@ import java.lang.reflect.Method;
 import java.util.Date;
 import javax.validation.ConstraintDeclarationException;
 import javax.validation.ConstraintTarget;
-import javax.validation.Validator;
-import javax.validation.executable.ExecutableValidator;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import org.hibernate.beanvalidation.tck.util.TestUtil;
+import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
 import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
+import static org.hibernate.beanvalidation.tck.util.TestUtil.webArchiveBuilder;
 import static org.testng.Assert.fail;
 
 /**
  * @author Gunnar Morling
  */
 @SpecVersion(spec = "beanvalidation", version = "2.0.0")
-public class InvalidDeclarationOfGenericAndCrossParameterConstraintTest extends Arquillian {
-
-	private Validator validator;
-	private ExecutableValidator executableValidator;
+public class InvalidDeclarationOfGenericAndCrossParameterConstraintTest extends BaseExecutableValidatorTest {
 
 	@Deployment
 	public static WebArchive createTestArchive() {
-		return new WebArchiveBuilder()
+		return webArchiveBuilder()
 				.withTestClassPackage( InvalidDeclarationOfGenericAndCrossParameterConstraintTest.class )
 				.build();
-	}
-
-	@BeforeMethod
-	public void setupValidator() {
-		validator = TestUtil.getValidatorUnderTest();
-		executableValidator = validator.forExecutables();
 	}
 
 	@Test(expectedExceptions = ConstraintDeclarationException.class)
@@ -62,7 +50,7 @@ public class InvalidDeclarationOfGenericAndCrossParameterConstraintTest extends 
 		Method method = Foo.class.getMethod( "createEvent", Date.class, Date.class );
 		Object[] parameterValues = new Object[2];
 
-		executableValidator.validateParameters( object, method, parameterValues );
+		getExecutableValidator().validateParameters( object, method, parameterValues );
 		fail( "Usage of ConstraintTarget.IMPLICIT not allowed for methods with parameters and return value. Expected exception wasn't thrown." );
 	}
 
@@ -77,7 +65,7 @@ public class InvalidDeclarationOfGenericAndCrossParameterConstraintTest extends 
 		Constructor<?> constructor = Bar.class.getConstructor( Date.class, Date.class );
 		Object[] parameterValues = new Object[2];
 
-		executableValidator.validateConstructorParameters( constructor, parameterValues );
+		getExecutableValidator().validateConstructorParameters( constructor, parameterValues );
 		fail( "Usage of ConstraintTarget.IMPLICIT not allowed for constructors with parameters. Expected exception wasn't thrown." );
 	}
 
@@ -92,7 +80,7 @@ public class InvalidDeclarationOfGenericAndCrossParameterConstraintTest extends 
 		Method method = Qux.class.getMethod( "qux" );
 		Object[] parameterValues = new Object[0];
 
-		executableValidator.validateParameters( object, method, parameterValues );
+		getExecutableValidator().validateParameters( object, method, parameterValues );
 		fail( "Usage of ConstraintTarget.PARAMETERS not allowed for methods without parameters. Expected exception wasn't thrown." );
 	}
 
@@ -106,7 +94,7 @@ public class InvalidDeclarationOfGenericAndCrossParameterConstraintTest extends 
 		Constructor<?> constructor = Baz.class.getConstructor();
 		Object[] parameterValues = new Object[0];
 
-		executableValidator.validateConstructorParameters( constructor, parameterValues );
+		getExecutableValidator().validateConstructorParameters( constructor, parameterValues );
 		fail( "Usage of ConstraintTarget.PARAMETERS not allowed for constructors without parameters. Expected exception wasn't thrown." );
 	}
 
@@ -120,7 +108,7 @@ public class InvalidDeclarationOfGenericAndCrossParameterConstraintTest extends 
 		Method method = Zap.class.getMethod( "zap" );
 		Object returnValue = null;
 
-		executableValidator.validateReturnValue( object, method, returnValue );
+		getExecutableValidator().validateReturnValue( object, method, returnValue );
 		fail( "Usage of ConstraintTarget.RETURN_VALUE not allowed for methods without return value. Expected exception wasn't thrown." );
 	}
 
@@ -130,7 +118,7 @@ public class InvalidDeclarationOfGenericAndCrossParameterConstraintTest extends 
 			@SpecAssertion(section = "3.1.1.4", id = "g")
 	})
 	public void testConstraintTargetParametersOnClassCausesException() throws Exception {
-		validator.validate( new TypeWithConstraintTargetParameter() );
+		getValidator().validate( new TypeWithConstraintTargetParameter() );
 		fail( "Usage of ConstraintTarget.PARAMETERS not allowed on type definitions. Expected exception wasn't thrown." );
 	}
 
@@ -140,7 +128,7 @@ public class InvalidDeclarationOfGenericAndCrossParameterConstraintTest extends 
 			@SpecAssertion(section = "3.1.1.4", id = "g")
 	})
 	public void testConstraintTargetReturnValueOnClassCausesException() throws Exception {
-		validator.validate( new TypeWithConstraintTargetReturnValue() );
+		getValidator().validate( new TypeWithConstraintTargetReturnValue() );
 		fail( "Usage of ConstraintTarget.RETURN_VALUE not allowed on type definitions. Expected exception wasn't thrown." );
 	}
 
@@ -150,7 +138,7 @@ public class InvalidDeclarationOfGenericAndCrossParameterConstraintTest extends 
 			@SpecAssertion(section = "3.1.1.4", id = "g")
 	})
 	public void testConstraintTargetParametersOnInterfaceCausesException() throws Exception {
-		validator.validate( new InterfaceWithConstraintTargetParameterImpl() );
+		getValidator().validate( new InterfaceWithConstraintTargetParameterImpl() );
 		fail( "Usage of ConstraintTarget.PARAMETERS not allowed on interface definitions. Expected exception wasn't thrown." );
 	}
 
@@ -160,7 +148,7 @@ public class InvalidDeclarationOfGenericAndCrossParameterConstraintTest extends 
 			@SpecAssertion(section = "3.1.1.4", id = "g")
 	})
 	public void testConstraintTargetReturnValueOnInterfaceCausesException() throws Exception {
-		validator.validate( new InterfaceWithConstraintTargetReturnValueImpl() );
+		getValidator().validate( new InterfaceWithConstraintTargetReturnValueImpl() );
 		fail( "Usage of ConstraintTarget.RETURN_VALUE not allowed on interface definitions. Expected exception wasn't thrown." );
 	}
 
@@ -170,7 +158,7 @@ public class InvalidDeclarationOfGenericAndCrossParameterConstraintTest extends 
 			@SpecAssertion(section = "3.1.1.4", id = "g")
 	})
 	public void testConstraintTargetParametersOnFieldCausesException() throws Exception {
-		validator.validate( new TypeWithFieldWithConstraintTargetParameter() );
+		getValidator().validate( new TypeWithFieldWithConstraintTargetParameter() );
 		fail( "Usage of ConstraintTarget.PARAMETERS not allowed on fields. Expected exception wasn't thrown." );
 	}
 
@@ -180,7 +168,7 @@ public class InvalidDeclarationOfGenericAndCrossParameterConstraintTest extends 
 			@SpecAssertion(section = "3.1.1.4", id = "g")
 	})
 	public void testConstraintTargetReturnValueOnFieldCausesException() throws Exception {
-		validator.validate( new TypeWithFieldWithConstraintTargetReturnValue() );
+		getValidator().validate( new TypeWithFieldWithConstraintTargetReturnValue() );
 		fail( "Usage of ConstraintTarget.RETURN_VALUE not allowed on fields. Expected exception wasn't thrown." );
 	}
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/groups/groupconversion/InvalidGroupDefinitionsTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/groups/groupconversion/InvalidGroupDefinitionsTest.java
@@ -6,21 +6,21 @@
  */
 package org.hibernate.beanvalidation.tck.tests.constraints.groups.groupconversion;
 
+import static org.hibernate.beanvalidation.tck.util.TestUtil.webArchiveBuilder;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.List;
 import javax.validation.ConstraintDeclarationException;
-import javax.validation.Validator;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
 import org.hibernate.beanvalidation.tck.tests.constraints.groups.groupconversion.model.User;
 import org.hibernate.beanvalidation.tck.tests.constraints.groups.groupconversion.model.UserWithGroupConversionButWithoutValidAnnotationConstructorParameter;
 import org.hibernate.beanvalidation.tck.tests.constraints.groups.groupconversion.model.UserWithGroupConversionButWithoutValidAnnotationOnConstructorReturnValue;
@@ -37,7 +37,6 @@ import org.hibernate.beanvalidation.tck.tests.constraints.groups.groupconversion
 import org.hibernate.beanvalidation.tck.tests.constraints.groups.groupconversion.service.impl.ImplementationOfParallelInterfacesWithGroupConversionOnReturnValue;
 import org.hibernate.beanvalidation.tck.tests.constraints.groups.groupconversion.service.impl.InterfaceImplementationWithGroupConversionOnParameter;
 import org.hibernate.beanvalidation.tck.tests.constraints.groups.groupconversion.service.impl.SubClassWithGroupConversionOnParameter;
-import org.hibernate.beanvalidation.tck.util.TestUtil;
 import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
 /**
@@ -46,13 +45,11 @@ import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
  * @author Gunnar Morling
  */
 @SpecVersion(spec = "beanvalidation", version = "2.0.0")
-public class InvalidGroupDefinitionsTest extends Arquillian {
-
-	private Validator validator;
+public class InvalidGroupDefinitionsTest extends BaseExecutableValidatorTest {
 
 	@Deployment
 	public static WebArchive createTestArchive() {
-		return new WebArchiveBuilder()
+		return webArchiveBuilder()
 				.withTestClassPackage( InvalidGroupDefinitionsTest.class )
 				.withPackage( User.class.getPackage() )
 				.withPackage( SubClassWithGroupConversionOnParameter.class.getPackage() )
@@ -60,21 +57,16 @@ public class InvalidGroupDefinitionsTest extends Arquillian {
 				.build();
 	}
 
-	@BeforeMethod
-	public void setupValidator() {
-		validator = TestUtil.getValidatorUnderTest();
-	}
-
 	@Test(expectedExceptions = ConstraintDeclarationException.class)
 	@SpecAssertion(section = "4.4.5", id = "a")
 	public void testGroupConversionWithoutValidAnnotationOnField() {
-		validator.validate( new UserWithGroupConversionButWithoutValidAnnotationOnField() );
+		getValidator().validate( new UserWithGroupConversionButWithoutValidAnnotationOnField() );
 	}
 
 	@Test(expectedExceptions = ConstraintDeclarationException.class)
 	@SpecAssertion(section = "4.4.5", id = "a")
 	public void testGroupConversionWithoutValidAnnotationOnProperty() {
-		validator.validate( new UserWithGroupConversionButWithoutValidAnnotationOnProperty() );
+		getValidator().validate( new UserWithGroupConversionButWithoutValidAnnotationOnProperty() );
 	}
 
 	@Test(expectedExceptions = ConstraintDeclarationException.class)
@@ -86,7 +78,7 @@ public class InvalidGroupDefinitionsTest extends Arquillian {
 		);
 		Object returnValue = null;
 
-		validator.forExecutables().validateReturnValue( object, method, returnValue );
+		getExecutableValidator().validateReturnValue( object, method, returnValue );
 	}
 
 	@Test(expectedExceptions = ConstraintDeclarationException.class)
@@ -99,7 +91,7 @@ public class InvalidGroupDefinitionsTest extends Arquillian {
 		);
 		Object[] parameters = new Object[] { null };
 
-		validator.forExecutables().validateParameters( object, method, parameters );
+		getExecutableValidator().validateParameters( object, method, parameters );
 	}
 
 	@Test(expectedExceptions = ConstraintDeclarationException.class)
@@ -110,7 +102,7 @@ public class InvalidGroupDefinitionsTest extends Arquillian {
 		Constructor<UserWithGroupConversionButWithoutValidAnnotationOnConstructorReturnValue> constructor = UserWithGroupConversionButWithoutValidAnnotationOnConstructorReturnValue.class
 				.getConstructor();
 
-		validator.forExecutables().validateConstructorReturnValue( constructor, object );
+		getExecutableValidator().validateConstructorReturnValue( constructor, object );
 	}
 
 	@Test(expectedExceptions = ConstraintDeclarationException.class)
@@ -120,19 +112,19 @@ public class InvalidGroupDefinitionsTest extends Arquillian {
 				.getConstructor( List.class );
 		Object[] parameters = new Object[] { null };
 
-		validator.forExecutables().validateConstructorParameters( constructor, parameters );
+		getExecutableValidator().validateConstructorParameters( constructor, parameters );
 	}
 
 	@Test(expectedExceptions = ConstraintDeclarationException.class)
 	@SpecAssertion(section = "4.4.5", id = "e")
 	public void testSeveralGroupConversionsWithSameFrom() {
-		validator.validate( new UserWithSeveralGroupConversionsForSameFrom() );
+		getValidator().validate( new UserWithSeveralGroupConversionsForSameFrom() );
 	}
 
 	@Test(expectedExceptions = ConstraintDeclarationException.class)
 	@SpecAssertion(section = "4.4.5", id = "f")
 	public void testGroupConversionWithSequenceAsFrom() {
-		validator.validate( new UserWithGroupConversionWithSequenceAsFrom() );
+		getValidator().validate( new UserWithGroupConversionWithSequenceAsFrom() );
 	}
 
 	@Test(expectedExceptions = ConstraintDeclarationException.class)
@@ -148,7 +140,7 @@ public class InvalidGroupDefinitionsTest extends Arquillian {
 		);
 		Object[] parameters = new Object[] { null };
 
-		validator.forExecutables().validateParameters( object, method, parameters );
+		getExecutableValidator().validateParameters( object, method, parameters );
 	}
 
 	@Test(expectedExceptions = ConstraintDeclarationException.class)
@@ -164,7 +156,7 @@ public class InvalidGroupDefinitionsTest extends Arquillian {
 		);
 		Object[] parameters = new Object[] { null };
 
-		validator.forExecutables().validateParameters( object, method, parameters );
+		getExecutableValidator().validateParameters( object, method, parameters );
 	}
 
 	@Test(expectedExceptions = ConstraintDeclarationException.class)
@@ -180,7 +172,7 @@ public class InvalidGroupDefinitionsTest extends Arquillian {
 		);
 		Object[] parameters = new Object[] { null };
 
-		validator.forExecutables().validateParameters( object, method, parameters );
+		getExecutableValidator().validateParameters( object, method, parameters );
 	}
 
 	@Test(expectedExceptions = ConstraintDeclarationException.class)
@@ -195,7 +187,7 @@ public class InvalidGroupDefinitionsTest extends Arquillian {
 		);
 		Object returnValue = null;
 
-		validator.forExecutables().validateReturnValue( object, method, returnValue );
+		getExecutableValidator().validateReturnValue( object, method, returnValue );
 	}
 
 	@Test(expectedExceptions = ConstraintDeclarationException.class)
@@ -210,7 +202,7 @@ public class InvalidGroupDefinitionsTest extends Arquillian {
 				.getMethod( "addUser", User.class );
 		Object[] parameters = new Object[] { null };
 
-		validator.forExecutables().validateParameters( object, method, parameters );
+		getExecutableValidator().validateParameters( object, method, parameters );
 	}
 
 	@Test(expectedExceptions = ConstraintDeclarationException.class)
@@ -225,6 +217,6 @@ public class InvalidGroupDefinitionsTest extends Arquillian {
 				.getMethod( "getUser" );
 		Object returnValue = null;
 
-		validator.forExecutables().validateReturnValue( object, method, returnValue );
+		getExecutableValidator().validateReturnValue( object, method, returnValue );
 	}
 }

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/inheritance/ConstraintInheritanceTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/inheritance/ConstraintInheritanceTest.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import javax.validation.ConstraintViolation;
-import javax.validation.Validator;
 import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
@@ -20,18 +19,16 @@ import javax.validation.metadata.ConstraintDescriptor;
 import javax.validation.metadata.PropertyDescriptor;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import org.hibernate.beanvalidation.tck.util.TestUtil;
-import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
+import org.hibernate.beanvalidation.tck.tests.BaseValidatorTest;
 
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectConstraintTypes;
+import static org.hibernate.beanvalidation.tck.util.TestUtil.webArchiveBuilder;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -39,26 +36,19 @@ import static org.testng.Assert.assertTrue;
  * @author Hardy Ferentschik
  */
 @SpecVersion(spec = "beanvalidation", version = "2.0.0")
-public class ConstraintInheritanceTest extends Arquillian {
-
-	private Validator validator;
+public class ConstraintInheritanceTest extends BaseValidatorTest {
 
 	@Deployment
 	public static WebArchive createTestArchive() {
-		return new WebArchiveBuilder()
+		return webArchiveBuilder()
 				.withTestClassPackage( ConstraintInheritanceTest.class )
 				.build();
-	}
-
-	@BeforeMethod
-	public void setupValidator() {
-		validator = TestUtil.getValidatorUnderTest();
 	}
 
 	@Test
 	@SpecAssertion(section = "4.3", id = "b")
 	public void testConstraintsOnSuperClassAreInherited() {
-		BeanDescriptor beanDescriptor = validator.getConstraintsForClass( Bar.class );
+		BeanDescriptor beanDescriptor = getValidator().getConstraintsForClass( Bar.class );
 
 		String propertyName = "foo";
 		assertTrue( beanDescriptor.getConstraintsForProperty( propertyName ) != null );
@@ -76,7 +66,7 @@ public class ConstraintInheritanceTest extends Arquillian {
 			@SpecAssertion(section = "4.3", id = "b")
 	})
 	public void testConstraintsOnInterfaceAreInherited() {
-		BeanDescriptor beanDescriptor = validator.getConstraintsForClass( Bar.class );
+		BeanDescriptor beanDescriptor = getValidator().getConstraintsForClass( Bar.class );
 
 		String propertyName = "fubar";
 		assertTrue( beanDescriptor.getConstraintsForProperty( propertyName ) != null );
@@ -94,7 +84,7 @@ public class ConstraintInheritanceTest extends Arquillian {
 			@SpecAssertion(section = "4.3", id = "c")
 	})
 	public void testConstraintsOnInterfaceAndImplementationAddUp() {
-		BeanDescriptor beanDescriptor = validator.getConstraintsForClass( Bar.class );
+		BeanDescriptor beanDescriptor = getValidator().getConstraintsForClass( Bar.class );
 
 		String propertyName = "name";
 		assertTrue( beanDescriptor.getConstraintsForProperty( propertyName ) != null );
@@ -113,7 +103,7 @@ public class ConstraintInheritanceTest extends Arquillian {
 			@SpecAssertion(section = "4.3", id = "c")
 	})
 	public void testConstraintsOnSuperAndSubClassAddUp() {
-		BeanDescriptor beanDescriptor = validator.getConstraintsForClass( Bar.class );
+		BeanDescriptor beanDescriptor = getValidator().getConstraintsForClass( Bar.class );
 
 		String propertyName = "lastName";
 		assertTrue( beanDescriptor.getConstraintsForProperty( propertyName ) != null );
@@ -129,7 +119,7 @@ public class ConstraintInheritanceTest extends Arquillian {
 	@Test
 	@SpecAssertion(section = "4.6", id = "a")
 	public void testValidationConsidersConstraintsFromSuperTypes() {
-		Set<ConstraintViolation<Bar>> violations = validator.validate( new Bar() );
+		Set<ConstraintViolation<Bar>> violations = getValidator().validate( new Bar() );
 		assertCorrectConstraintTypes(
 				violations,
 				DecimalMin.class, DecimalMin.class, ValidBar.class, //Bar

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/inheritance/method/invaliddeclarations/InvalidMethodConstraintDeclarationTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/inheritance/method/invaliddeclarations/InvalidMethodConstraintDeclarationTest.java
@@ -10,15 +10,12 @@ import java.lang.reflect.Method;
 import java.util.Date;
 import java.util.List;
 import javax.validation.ConstraintDeclarationException;
-import javax.validation.executable.ExecutableValidator;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.hibernate.beanvalidation.tck.tests.constraints.inheritance.method.invaliddeclarations.model.Order;
@@ -35,32 +32,26 @@ import org.hibernate.beanvalidation.tck.tests.constraints.inheritance.method.inv
 import org.hibernate.beanvalidation.tck.tests.constraints.inheritance.method.invaliddeclarations.service.impl.OrderServiceSubClass;
 import org.hibernate.beanvalidation.tck.tests.constraints.inheritance.method.invaliddeclarations.service.impl.SubClassAddingParameterConstraints;
 import org.hibernate.beanvalidation.tck.tests.constraints.inheritance.method.invaliddeclarations.service.impl.SubClassMarkingParameterAsCascaded;
-import org.hibernate.beanvalidation.tck.util.TestUtil;
+import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
 import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
+import static org.hibernate.beanvalidation.tck.util.TestUtil.webArchiveBuilder;
 import static org.testng.Assert.fail;
 
 /**
  * @author Gunnar Morling
  */
 @SpecVersion(spec = "beanvalidation", version = "2.0.0")
-public class InvalidMethodConstraintDeclarationTest extends Arquillian {
-
-	private ExecutableValidator executableValidator;
+public class InvalidMethodConstraintDeclarationTest extends BaseExecutableValidatorTest {
 
 	@Deployment
 	public static WebArchive createTestArchive() {
-		return new WebArchiveBuilder()
+		return webArchiveBuilder()
 				.withTestClassPackage( InvalidMethodConstraintDeclarationTest.class )
 				.withPackage( ImplementationAddingParameterConstraints.class.getPackage() )
 				.withPackage( AbstractCalendarService.class.getPackage() )
 				.withPackage( Person.class.getPackage() )
 				.build();
-	}
-
-	@BeforeMethod
-	public void setupValidator() {
-		executableValidator = TestUtil.getValidatorUnderTest().forExecutables();
 	}
 
 	@Test(expectedExceptions = ConstraintDeclarationException.class)
@@ -74,7 +65,7 @@ public class InvalidMethodConstraintDeclarationTest extends Arquillian {
 		Method method = getCreateEventMethod( object );
 		Object[] parameterValues = new Object[3];
 
-		executableValidator.validateParameters( object, method, parameterValues );
+		getExecutableValidator().validateParameters( object, method, parameterValues );
 		fail( "Implementing method must add no parameter constraints. Expected exception wasn't thrown." );
 	}
 
@@ -88,7 +79,7 @@ public class InvalidMethodConstraintDeclarationTest extends Arquillian {
 		Method method = getCreateEventMethod( object );
 		Object[] parameterValues = new Object[3];
 
-		executableValidator.validateParameters( object, method, parameterValues );
+		getExecutableValidator().validateParameters( object, method, parameterValues );
 		fail( "Overriding subclass method must add no parameter constraints. Expected exception wasn't thrown." );
 	}
 
@@ -103,7 +94,7 @@ public class InvalidMethodConstraintDeclarationTest extends Arquillian {
 		Method method = getCreateEventMethod( object );
 		Object[] parameterValues = new Object[3];
 
-		executableValidator.validateParameters( object, method, parameterValues );
+		getExecutableValidator().validateParameters( object, method, parameterValues );
 		fail( "Implementing method must not mark a parameter cascaded. Expected exception wasn't thrown." );
 	}
 
@@ -117,7 +108,7 @@ public class InvalidMethodConstraintDeclarationTest extends Arquillian {
 		Method method = getCreateEventMethod( object );
 		Object[] parameterValues = new Object[3];
 
-		executableValidator.validateParameters( object, method, parameterValues );
+		getExecutableValidator().validateParameters( object, method, parameterValues );
 		fail( "Overriding subclass method must not mark a parameter cascaded. Expected exception wasn't thrown." );
 	}
 
@@ -132,7 +123,7 @@ public class InvalidMethodConstraintDeclarationTest extends Arquillian {
 		Method method = getCreateEventMethod( object );
 		Object[] parameterValues = new Object[3];
 
-		executableValidator.validateParameters( object, method, parameterValues );
+		getExecutableValidator().validateParameters( object, method, parameterValues );
 		fail( "A method defined in two parallel interfaces must have no parameter constraints. Expected exception wasn't thrown." );
 	}
 
@@ -147,7 +138,7 @@ public class InvalidMethodConstraintDeclarationTest extends Arquillian {
 		Method method = getCreateEventMethod( object );
 		Object[] parameterValues = new Object[3];
 
-		executableValidator.validateParameters( object, method, parameterValues );
+		getExecutableValidator().validateParameters( object, method, parameterValues );
 		fail( "A method defined in an interface and a superclass not implementing this interface must have no parameter constraints. Expected exception wasn't thrown." );
 	}
 
@@ -162,7 +153,7 @@ public class InvalidMethodConstraintDeclarationTest extends Arquillian {
 		Method method = getCreateEventMethod( object );
 		Object[] parameterValues = new Object[3];
 
-		executableValidator.validateParameters( object, method, parameterValues );
+		getExecutableValidator().validateParameters( object, method, parameterValues );
 		fail( "A method defined in two parallel interfaces must not have no parameters marked as cascaded. Expected exception wasn't thrown." );
 	}
 
@@ -177,7 +168,7 @@ public class InvalidMethodConstraintDeclarationTest extends Arquillian {
 		Method method = getCreateEventMethod( object );
 		Object[] parameterValues = new Object[3];
 
-		executableValidator.validateParameters( object, method, parameterValues );
+		getExecutableValidator().validateParameters( object, method, parameterValues );
 		fail( "A method defined in an interface and a superclass not implementing this interface must have no parameters marked as cascaded. Expected exception wasn't thrown." );
 	}
 
@@ -192,7 +183,7 @@ public class InvalidMethodConstraintDeclarationTest extends Arquillian {
 		Method method = getPlaceOrderMethod( object );
 		Object returnValue = new Order();
 
-		executableValidator.validateReturnValue( object, method, returnValue );
+		getExecutableValidator().validateReturnValue( object, method, returnValue );
 		fail( "A method must not mark the return value as cascaded if the implemented interface method is cascaded, too. Expected exception wasn't thrown." );
 	}
 
@@ -207,7 +198,7 @@ public class InvalidMethodConstraintDeclarationTest extends Arquillian {
 		Method method = getPlaceOrderMethod( object );
 		Object returnValue = new Order();
 
-		executableValidator.validateReturnValue( object, method, returnValue );
+		getExecutableValidator().validateReturnValue( object, method, returnValue );
 		fail( "A method must not mark the return value as cascaded if the overridden superclass method is cascaded, too. Expected exception wasn't thrown." );
 	}
 
@@ -222,7 +213,7 @@ public class InvalidMethodConstraintDeclarationTest extends Arquillian {
 		Method method = getPlaceOrderMethod( object );
 		Object returnValue = new Order();
 
-		executableValidator.validateReturnValue( object, method, returnValue );
+		getExecutableValidator().validateReturnValue( object, method, returnValue );
 		fail( "An interface method must not mark the return value as cascaded if the overridden superinterface method is cascaded, too. Expected exception wasn't thrown." );
 	}
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/inheritance/method/validdeclarations/ValidMethodConstraintDeclarationTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/inheritance/method/validdeclarations/ValidMethodConstraintDeclarationTest.java
@@ -14,14 +14,11 @@ import java.util.Set;
 import javax.validation.ConstraintViolation;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
-import javax.validation.executable.ExecutableValidator;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.hibernate.beanvalidation.tck.tests.constraints.inheritance.method.validdeclarations.constraint.ValidBusinessCalendarEvent;
@@ -33,34 +30,29 @@ import org.hibernate.beanvalidation.tck.tests.constraints.inheritance.method.val
 import org.hibernate.beanvalidation.tck.tests.constraints.inheritance.method.validdeclarations.service.impl.CalendarServiceImplementation;
 import org.hibernate.beanvalidation.tck.tests.constraints.inheritance.method.validdeclarations.service.impl.CalendarServiceSubClass;
 import org.hibernate.beanvalidation.tck.tests.constraints.inheritance.method.validdeclarations.service.impl.ImplementationOfParallelInterfacesMarkingReturnValueAsCascaded;
+import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
 import org.hibernate.beanvalidation.tck.util.TestUtil;
 import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectConstraintTypes;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertNodeNames;
+import static org.hibernate.beanvalidation.tck.util.TestUtil.webArchiveBuilder;
 
 /**
  * @author Gunnar Morling
  */
 @SpecVersion(spec = "beanvalidation", version = "2.0.0")
-public class ValidMethodConstraintDeclarationTest extends Arquillian {
-
-	private ExecutableValidator executableValidator;
+public class ValidMethodConstraintDeclarationTest extends BaseExecutableValidatorTest {
 
 	@Deployment
 	public static WebArchive createTestArchive() {
-		return new WebArchiveBuilder()
+		return webArchiveBuilder()
 				.withTestClassPackage( ValidMethodConstraintDeclarationTest.class )
 				.withPackage( ValidCalendarEvent.class.getPackage() )
 				.withPackage( CalendarEvent.class.getPackage() )
 				.withPackage( CalendarServiceImplementation.class.getPackage() )
 				.withPackage( CalendarService.class.getPackage() )
 				.build();
-	}
-
-	@BeforeMethod
-	public void setupValidator() {
-		executableValidator = TestUtil.getValidatorUnderTest().forExecutables();
 	}
 
 	@Test
@@ -70,7 +62,7 @@ public class ValidMethodConstraintDeclarationTest extends Arquillian {
 		Method method = getCreateEventMethod( object );
 		Object returnValue = null;
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
@@ -86,7 +78,7 @@ public class ValidMethodConstraintDeclarationTest extends Arquillian {
 		Method method = getCreateEventMethod( object );
 		Object returnValue = null;
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
@@ -102,7 +94,7 @@ public class ValidMethodConstraintDeclarationTest extends Arquillian {
 		Method method = getCreateEventWithDurationMethod( object );
 		Object returnValue = new CalendarEvent();
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
@@ -124,7 +116,7 @@ public class ValidMethodConstraintDeclarationTest extends Arquillian {
 		Method method = getCreateEventWithParticipantsMethod( object );
 		Object returnValue = null;
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
@@ -140,7 +132,7 @@ public class ValidMethodConstraintDeclarationTest extends Arquillian {
 		Method method = getCreateEventWithParticipantsMethod( object );
 		Object returnValue = null;
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
@@ -161,7 +153,7 @@ public class ValidMethodConstraintDeclarationTest extends Arquillian {
 		Method method = getCreateEventWithDurationMethod( object );
 		Object returnValue = new CalendarEvent();
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
@@ -182,7 +174,7 @@ public class ValidMethodConstraintDeclarationTest extends Arquillian {
 		Constructor<?> constructor = CalendarServiceSubClass.class.getConstructor( int.class );
 		Object[] parameterValues = new Object[] { 4 };
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
@@ -196,7 +188,7 @@ public class ValidMethodConstraintDeclarationTest extends Arquillian {
 		Constructor<?> constructor = CalendarServiceSubClass.class.getConstructor( CalendarEvent.class );
 		Object[] parameterValues = new Object[] { new CalendarEvent() };
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
@@ -216,7 +208,7 @@ public class ValidMethodConstraintDeclarationTest extends Arquillian {
 		Constructor<?> constructor = CalendarServiceSubClass.class.getConstructor( String.class );
 		Object returnValue = new CalendarServiceSubClass();
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateConstructorReturnValue(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateConstructorReturnValue(
 				constructor,
 				returnValue
 		);
@@ -236,7 +228,7 @@ public class ValidMethodConstraintDeclarationTest extends Arquillian {
 		Constructor<?> constructor = CalendarServiceSubClass.class.getConstructor( long.class );
 		Object returnValue = new CalendarServiceSubClass();
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateConstructorReturnValue(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateConstructorReturnValue(
 				constructor,
 				returnValue
 		);
@@ -257,7 +249,7 @@ public class ValidMethodConstraintDeclarationTest extends Arquillian {
 		Method method = getCreateEventMethod( object );
 		Object returnValue = new CalendarEvent();
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/invalidconstraintdefinitions/InvalidConstraintDefinitionsTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/invalidconstraintdefinitions/InvalidConstraintDefinitionsTest.java
@@ -9,21 +9,18 @@ package org.hibernate.beanvalidation.tck.tests.constraints.invalidconstraintdefi
 import java.lang.reflect.Method;
 import java.util.Date;
 import javax.validation.ConstraintDefinitionException;
-import javax.validation.Validator;
-import javax.validation.executable.ExecutableValidator;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import org.hibernate.beanvalidation.tck.util.TestUtil;
+import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
 import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
+import static org.hibernate.beanvalidation.tck.util.TestUtil.webArchiveBuilder;
 import static org.testng.Assert.fail;
 
 /**
@@ -31,22 +28,13 @@ import static org.testng.Assert.fail;
  * @author Gunnar Morling
  */
 @SpecVersion(spec = "beanvalidation", version = "2.0.0")
-public class InvalidConstraintDefinitionsTest extends Arquillian {
-
-	private Validator validator;
-	private ExecutableValidator executableValidator;
+public class InvalidConstraintDefinitionsTest extends BaseExecutableValidatorTest {
 
 	@Deployment
 	public static WebArchive createTestArchive() {
-		return new WebArchiveBuilder()
+		return webArchiveBuilder()
 				.withTestClassPackage( InvalidConstraintDefinitionsTest.class )
 				.build();
-	}
-
-	@BeforeMethod
-	public void setupValidators() {
-		validator = TestUtil.getValidatorUnderTest();
-		executableValidator = validator.forExecutables();
 	}
 
 	@Test(expectedExceptions = ConstraintDefinitionException.class)
@@ -56,7 +44,7 @@ public class InvalidConstraintDefinitionsTest extends Arquillian {
 			@SpecAssertion(section = "9.2", id = "a")
 	})
 	public void testConstraintDefinitionWithParameterStartingWithValid() {
-		validator.validate( new DummyEntityValidProperty() );
+		getValidator().validate( new DummyEntityValidProperty() );
 		fail( "The used constraint does use an invalid property name. The validation should have failed." );
 	}
 
@@ -69,7 +57,7 @@ public class InvalidConstraintDefinitionsTest extends Arquillian {
 			@SpecAssertion(section = "9.2", id = "a")
 	})
 	public void testConstraintDefinitionWithoutMessageParameter() {
-		validator.validate( new DummyEntityNoMessage() );
+		getValidator().validate( new DummyEntityNoMessage() );
 		fail( "The used constraint does not define a message parameter. The validation should have failed." );
 	}
 
@@ -80,7 +68,7 @@ public class InvalidConstraintDefinitionsTest extends Arquillian {
 			@SpecAssertion(section = "9.2", id = "a")
 	})
 	public void testConstraintDefinitionWithoutGroupParameter() {
-		validator.validate( new DummyEntityNoGroups() );
+		getValidator().validate( new DummyEntityNoGroups() );
 		fail( "The used constraint does not define a groups parameter. The validation should have failed." );
 	}
 
@@ -91,7 +79,7 @@ public class InvalidConstraintDefinitionsTest extends Arquillian {
 			@SpecAssertion(section = "9.2", id = "a")
 	})
 	public void testConstraintDefinitionWithoutPayloadParameter() {
-		validator.validate( new DummyEntityNoGroups() );
+		getValidator().validate( new DummyEntityNoGroups() );
 		fail( "The used constraint does not define a payload parameter. The validation should have failed." );
 	}
 
@@ -102,7 +90,7 @@ public class InvalidConstraintDefinitionsTest extends Arquillian {
 			@SpecAssertion(section = "9.2", id = "a")
 	})
 	public void testConstraintDefinitionWithWrongDefaultGroupValue() {
-		validator.validate( new DummyEntityInvalidDefaultGroup() );
+		getValidator().validate( new DummyEntityInvalidDefaultGroup() );
 		fail( "The default groups parameter is not the empty array. The validation should have failed." );
 	}
 
@@ -113,7 +101,7 @@ public class InvalidConstraintDefinitionsTest extends Arquillian {
 			@SpecAssertion(section = "9.2", id = "a")
 	})
 	public void testConstraintDefinitionWithWrongDefaultPayloadValue() {
-		validator.validate( new DummyEntityInvalidDefaultPayload() );
+		getValidator().validate( new DummyEntityInvalidDefaultPayload() );
 		fail( "The default payload parameter is not the empty array. The validation should have failed." );
 	}
 
@@ -125,7 +113,7 @@ public class InvalidConstraintDefinitionsTest extends Arquillian {
 			@SpecAssertion(section = "9.2", id = "a")
 	})
 	public void testConstraintDefinitionWithWrongPayloadClass() {
-		validator.validate( new DummyEntityInvalidPayloadClass() );
+		getValidator().validate( new DummyEntityInvalidPayloadClass() );
 		fail( "The default payload parameter has to be of type Class<? extends Payload>[]. The validation should have failed." );
 	}
 
@@ -136,7 +124,7 @@ public class InvalidConstraintDefinitionsTest extends Arquillian {
 			@SpecAssertion(section = "9.2", id = "a")
 	})
 	public void testConstraintDefinitionWithWrongMessageType() {
-		validator.validate( new DummyEntityInvalidMessageType() );
+		getValidator().validate( new DummyEntityInvalidMessageType() );
 		fail( "The message parameter has to be of type String. The validation should have failed." );
 	}
 
@@ -147,7 +135,7 @@ public class InvalidConstraintDefinitionsTest extends Arquillian {
 			@SpecAssertion(section = "9.2", id = "a")
 	})
 	public void testConstraintDefinitionWithWrongGroupType() {
-		validator.validate( new DummyEntityInvalidGroupsType() );
+		getValidator().validate( new DummyEntityInvalidGroupsType() );
 		fail( "The groups parameter has to be of type Class<?>[]. The validation should have failed." );
 	}
 
@@ -158,7 +146,7 @@ public class InvalidConstraintDefinitionsTest extends Arquillian {
 		Method method = CalendarService.class.getMethod( "createEvent", Date.class, Date.class );
 		Object[] parameterValues = new Object[2];
 
-		executableValidator.validateParameters( object, method, parameterValues );
+		getExecutableValidator().validateParameters( object, method, parameterValues );
 		fail( "Validators for cross-parameter constraints must validate the type Object or Object[]. Expected exception wasn't thrown." );
 	}
 
@@ -174,7 +162,7 @@ public class InvalidConstraintDefinitionsTest extends Arquillian {
 		);
 		Object[] parameterValues = new Object[2];
 
-		executableValidator.validateParameters( object, method, parameterValues );
+		getExecutableValidator().validateParameters( object, method, parameterValues );
 		fail( "There must be only one validator for a cross-parameter constraint. Expected exception wasn't thrown." );
 	}
 
@@ -190,7 +178,7 @@ public class InvalidConstraintDefinitionsTest extends Arquillian {
 		);
 		Object[] parameterValues = new Object[2];
 
-		executableValidator.validateParameters( object, method, parameterValues );
+		getExecutableValidator().validateParameters( object, method, parameterValues );
 		fail( "There must be only one validator for a cross-parameter constraint. Expected exception wasn't thrown." );
 	}
 
@@ -201,7 +189,7 @@ public class InvalidConstraintDefinitionsTest extends Arquillian {
 			@SpecAssertion(section = "9.2", id = "a")
 	})
 	public void testGenericAndCrossParameterConstraintWithoutValidationAppliesToCausesException() {
-		validator.validate( new DummyEntityNoValidationAppliesTo() );
+		getValidator().validate( new DummyEntityNoValidationAppliesTo() );
 		fail( "A constraint which is generic and cross-parameter needs to define a member validationAppliesTo. The validation should have failed." );
 	}
 
@@ -212,7 +200,7 @@ public class InvalidConstraintDefinitionsTest extends Arquillian {
 			@SpecAssertion(section = "9.2", id = "a")
 	})
 	public void testGenericConstraintWithValidationAppliesToCausesException() {
-		validator.validate( new DummyEntityWithUnexpectedValidationAppliesTo() );
+		getValidator().validate( new DummyEntityWithUnexpectedValidationAppliesTo() );
 		fail( "A pure generic constraint must not define a member validationAppliesTo. The validation should have failed." );
 	}
 
@@ -232,7 +220,7 @@ public class InvalidConstraintDefinitionsTest extends Arquillian {
 		);
 		Object[] parameterValues = new Object[2];
 
-		executableValidator.validateParameters( object, method, parameterValues );
+		getExecutableValidator().validateParameters( object, method, parameterValues );
 		fail( "A pure cross-parameter constraint must not define a member validationAppliesTo. The validation should have failed." );
 	}
 
@@ -243,7 +231,7 @@ public class InvalidConstraintDefinitionsTest extends Arquillian {
 			@SpecAssertion(section = "9.2", id = "a")
 	})
 	public void testConstraintDefinitionWithWrongValidationAppliesToType() {
-		validator.validate( new DummyEntityWithValidationAppliesToOfWrongType() );
+		getValidator().validate( new DummyEntityWithValidationAppliesToOfWrongType() );
 		fail( "The validationAppliesTo parameter has to be of type ConstraintTarget. The validation should have failed." );
 	}
 
@@ -254,7 +242,7 @@ public class InvalidConstraintDefinitionsTest extends Arquillian {
 			@SpecAssertion(section = "9.2", id = "a")
 	})
 	public void testConstraintDefinitionWithWrongDefaultValidationAppliesTo() {
-		validator.validate( new DummyEntityWithValidationAppliesToWithWrongDefaultValue() );
+		getValidator().validate( new DummyEntityWithValidationAppliesToWithWrongDefaultValue() );
 		fail( "The validationAppliesTo parameter must have a default value of ConstraintTarget.IMPLICIT. The validation should have failed." );
 	}
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/validatorresolution/ValidatorResolutionTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/validatorresolution/ValidatorResolutionTest.java
@@ -13,17 +13,15 @@ import javax.validation.ConstraintDefinitionException;
 import javax.validation.ConstraintTarget;
 import javax.validation.ConstraintViolation;
 import javax.validation.UnexpectedTypeException;
-import javax.validation.Validator;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import org.hibernate.beanvalidation.tck.util.TestUtil;
+import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
 import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertConstraintViolation;
@@ -31,6 +29,7 @@ import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectConstr
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectConstraintViolationMessages;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectNumberOfViolations;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectPropertyPaths;
+import static org.hibernate.beanvalidation.tck.util.TestUtil.webArchiveBuilder;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -42,20 +41,13 @@ import static org.testng.Assert.fail;
  * @author Gunnar Morling
  */
 @SpecVersion(spec = "beanvalidation", version = "2.0.0")
-public class ValidatorResolutionTest {
-
-	private Validator validator;
+public class ValidatorResolutionTest extends BaseExecutableValidatorTest{
 
 	@Deployment
 	public static WebArchive createTestArchive() {
-		return new WebArchiveBuilder()
+		return webArchiveBuilder()
 				.withTestClassPackage( ValidatorResolutionTest.class )
 				.build();
-	}
-
-	@BeforeMethod
-	public void setupValidator() {
-		validator = TestUtil.getValidatorUnderTest();
 	}
 
 	@Test
@@ -67,7 +59,7 @@ public class ValidatorResolutionTest {
 				"The validate method of ValidatorForCustomInterface should not have been called yet."
 		);
 
-		validator.validate( new CustomInterfaceImpl() );
+		getValidator().validate( new CustomInterfaceImpl() );
 
 		assertTrue(
 				CustomConstraint.ValidatorForCustomInterface.callCounter > 0,
@@ -84,7 +76,7 @@ public class ValidatorResolutionTest {
 				"The validate method of ValidatorForCustomClass should not have been called yet."
 		);
 
-		validator.validate( new CustomClass() );
+		getValidator().validate( new CustomClass() );
 
 		assertTrue(
 				CustomConstraint.ValidatorForCustomClass.callCounter > 0,
@@ -104,7 +96,7 @@ public class ValidatorResolutionTest {
 				"The validate method of ValidatorForSubClassA should not have been called yet."
 		);
 
-		validator.validate( new SubClassAHolder( new SubClassA() ) );
+		getValidator().validate( new SubClassAHolder( new SubClassA() ) );
 
 		assertTrue(
 				CustomConstraint.ValidatorForSubClassA.callCounter > 0,
@@ -124,7 +116,7 @@ public class ValidatorResolutionTest {
 				"The validate method of ValidatorForSubClassB should not have been called yet."
 		);
 
-		validator.validate( new SubClassBHolder( new SubClassB() ) );
+		getValidator().validate( new SubClassBHolder( new SubClassB() ) );
 
 		assertTrue(
 				CustomConstraint.ValidatorForSubClassB.callCounter > 0,
@@ -141,7 +133,7 @@ public class ValidatorResolutionTest {
 				"The validate method of ValidatorForAnotherSubClass should not have been called yet."
 		);
 
-		validator.validate( new AnotherSubClass() );
+		getValidator().validate( new AnotherSubClass() );
 
 		assertTrue(
 				CustomConstraint.ValidatorForAnotherSubClass.callCounter > 0,
@@ -157,22 +149,22 @@ public class ValidatorResolutionTest {
 		Suburb suburb = new Suburb();
 
 		// all values are null and should pass
-		Set<ConstraintViolation<Suburb>> constraintViolations = validator.validate( suburb );
+		Set<ConstraintViolation<Suburb>> constraintViolations = getValidator().validate( suburb );
 		assertCorrectNumberOfViolations( constraintViolations, 0 );
 
 		suburb.setName( "" );
-		constraintViolations = validator.validate( suburb );
+		constraintViolations = getValidator().validate( suburb );
 		assertCorrectNumberOfViolations( constraintViolations, 1 );
 		assertConstraintViolation(
 				constraintViolations.iterator().next(), Suburb.class, "", "name"
 		);
 
 		suburb.setName( "Hoegsbo" );
-		constraintViolations = validator.validate( suburb );
+		constraintViolations = getValidator().validate( suburb );
 		assertCorrectNumberOfViolations( constraintViolations, 0 );
 
 		suburb.addFacility( Suburb.Facility.SHOPPING_MALL, false );
-		constraintViolations = validator.validate( suburb );
+		constraintViolations = getValidator().validate( suburb );
 		assertCorrectNumberOfViolations( constraintViolations, 1 );
 		assertConstraintViolation(
 				constraintViolations.iterator().next(),
@@ -182,11 +174,11 @@ public class ValidatorResolutionTest {
 		);
 
 		suburb.addFacility( Suburb.Facility.BUS_TERMINAL, true );
-		constraintViolations = validator.validate( suburb );
+		constraintViolations = getValidator().validate( suburb );
 		assertCorrectNumberOfViolations( constraintViolations, 0 );
 
 		suburb.addStreetName( "Sikelsgatan" );
-		constraintViolations = validator.validate( suburb );
+		constraintViolations = getValidator().validate( suburb );
 		assertCorrectNumberOfViolations( constraintViolations, 1 );
 		assertConstraintViolation(
 				constraintViolations.iterator().next(),
@@ -196,7 +188,7 @@ public class ValidatorResolutionTest {
 		);
 
 		suburb.addStreetName( "Marklandsgatan" );
-		constraintViolations = validator.validate( suburb );
+		constraintViolations = getValidator().validate( suburb );
 		assertCorrectNumberOfViolations( constraintViolations, 0 );
 
 		Coordinate[] boundingBox = new Coordinate[3];
@@ -204,7 +196,7 @@ public class ValidatorResolutionTest {
 		boundingBox[1] = new Coordinate( 0l, 1l );
 		boundingBox[2] = new Coordinate( 1l, 0l );
 		suburb.setBoundingBox( boundingBox );
-		constraintViolations = validator.validate( suburb );
+		constraintViolations = getValidator().validate( suburb );
 		assertCorrectNumberOfViolations( constraintViolations, 1 );
 		assertConstraintViolation(
 				constraintViolations.iterator().next(),
@@ -219,7 +211,7 @@ public class ValidatorResolutionTest {
 		boundingBox[2] = new Coordinate( 1l, 0l );
 		boundingBox[3] = new Coordinate( 1l, 1l );
 		suburb.setBoundingBox( boundingBox );
-		constraintViolations = validator.validate( suburb );
+		constraintViolations = getValidator().validate( suburb );
 		assertCorrectNumberOfViolations( constraintViolations, 0 );
 	}
 
@@ -229,7 +221,7 @@ public class ValidatorResolutionTest {
 	})
 	public void testResolutionOfMinMaxForDifferentTypes() {
 		MinMax minMax = new MinMax( "5", 5 );
-		Set<ConstraintViolation<MinMax>> constraintViolations = validator.validate( minMax );
+		Set<ConstraintViolation<MinMax>> constraintViolations = getValidator().validate( minMax );
 		assertCorrectNumberOfViolations( constraintViolations, 2 );
 		assertCorrectPropertyPaths( constraintViolations, "number", "numberAsString" );
 	}
@@ -242,7 +234,7 @@ public class ValidatorResolutionTest {
 	})
 	public void testUnexpectedTypeInValidatorResolution() {
 		Bar bar = new Bar();
-		validator.validate( bar );
+		getValidator().validate( bar );
 	}
 
 	@Test(expectedExceptions = UnexpectedTypeException.class)
@@ -252,7 +244,7 @@ public class ValidatorResolutionTest {
 	})
 	public void testAmbiguousValidatorResolution() {
 		Foo foo = new Foo( new SerializableBarSubclass() );
-		validator.validate( foo );
+		getValidator().validate( foo );
 		fail( "The test should have failed due to ambiguous validator resolution." );
 	}
 
@@ -260,7 +252,7 @@ public class ValidatorResolutionTest {
 	@SpecAssertion(section = "4.6.4", id = "g")
 	public void testValidatorForWrapperTypeIsAppliedForPrimitiveType() {
 		PrimitiveHolder primitiveHolder = new PrimitiveHolder();
-		Set<ConstraintViolation<PrimitiveHolder>> violations = validator.validate( primitiveHolder );
+		Set<ConstraintViolation<PrimitiveHolder>> violations = getValidator().validate( primitiveHolder );
 
 		assertCorrectNumberOfViolations( violations, 2 );
 		assertCorrectConstraintTypes( violations, ValidInteger.class, ValidLong.class );
@@ -273,7 +265,7 @@ public class ValidatorResolutionTest {
 		Method method = CalendarService.class.getMethod( "createEvent", Date.class, Date.class );
 		Object[] parameterValues = new Object[2];
 
-		validator.forExecutables().validateParameters( object, method, parameterValues );
+		getExecutableValidator().validateParameters( object, method, parameterValues );
 	}
 
 	@Test(expectedExceptions = ConstraintDefinitionException.class)
@@ -283,7 +275,7 @@ public class ValidatorResolutionTest {
 		Method method = OnlineCalendarService.class.getMethod( "createEvent", Date.class, Date.class );
 		Object[] parameterValues = new Object[2];
 
-		validator.forExecutables().validateParameters( object, method, parameterValues );
+		getExecutableValidator().validateParameters( object, method, parameterValues );
 	}
 
 	@Test
@@ -293,7 +285,7 @@ public class ValidatorResolutionTest {
 		Method method = OfflineCalendarService.class.getMethod( "createEvent", Date.class, Date.class );
 		Object[] parameterValues = new Object[2];
 
-		Set<ConstraintViolation<Object>> violations = validator.forExecutables()
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator()
 				.validateParameters( object, method, parameterValues );
 
 		assertCorrectConstraintViolationMessages( violations, "violation created by cross-parameter validator" );
@@ -306,7 +298,7 @@ public class ValidatorResolutionTest {
 		Method method = AdvancedCalendarService.class.getMethod( "createEvent", Date.class, Date.class );
 		Object[] parameterValues = new Object[2];
 
-		Set<ConstraintViolation<Object>> violations = validator.forExecutables()
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator()
 				.validateParameters( object, method, parameterValues );
 		assertCorrectConstraintViolationMessages( violations, "violation created by cross-parameter validator" );
 	}
@@ -321,7 +313,7 @@ public class ValidatorResolutionTest {
 		Method method = YetAnotherCalendarService.class.getMethod( "createEvent", Date.class, Date.class );
 		Object[] parameterValues = new Object[2];
 
-		Set<ConstraintViolation<Object>> violations = validator.forExecutables()
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator()
 				.validateParameters( object, method, parameterValues );
 		assertCorrectConstraintViolationMessages( violations, "violation created by validator for Object[]" );
 	}
@@ -336,7 +328,7 @@ public class ValidatorResolutionTest {
 		Method method = EvenYetAnotherCalendarService.class.getMethod( "createEvent", Date.class, Date.class );
 		Object[] parameterValues = new Object[2];
 
-		Set<ConstraintViolation<Object>> violations = validator.forExecutables()
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator()
 				.validateParameters( object, method, parameterValues );
 		assertCorrectConstraintViolationMessages( violations, "violation created by validator for Object" );
 	}
@@ -348,7 +340,7 @@ public class ValidatorResolutionTest {
 		Method method = AnotherCalendarService.class.getMethod( "createEvent", Date.class, Date.class );
 		Object returnValue = null;
 
-		Set<ConstraintViolation<Object>> violations = validator.forExecutables()
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator()
 				.validateReturnValue( object, method, returnValue );
 		assertCorrectConstraintViolationMessages( violations, "violation created by generic validator" );
 	}
@@ -356,14 +348,14 @@ public class ValidatorResolutionTest {
 	@Test
 	@SpecAssertion(section = "4.6.4", id = "f")
 	public void testGenericValidatorIsUsedForConstraintTargetingField() {
-		Set<ConstraintViolation<TestBean>> violations = validator.validate( new TestBean() );
+		Set<ConstraintViolation<TestBean>> violations = getValidator().validate( new TestBean() );
 		assertCorrectConstraintViolationMessages( violations, "violation created by generic validator" );
 	}
 
 	@Test(expectedExceptions = UnexpectedTypeException.class)
 	@SpecAssertion(section = "4.6.4", id = "j")
 	public void testTwoValidatorsForSameTypeCauseUnexpectedTypeException() {
-		validator.validate( new AnotherBean() );
+		getValidator().validate( new AnotherBean() );
 	}
 
 	private static class SubClassAHolder {

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/messageinterpolation/ExpressionLanguageMessageInterpolationTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/messageinterpolation/ExpressionLanguageMessageInterpolationTest.java
@@ -23,7 +23,6 @@ import javax.validation.constraints.Size;
 import javax.validation.groups.Default;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
@@ -32,32 +31,28 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import org.hibernate.beanvalidation.tck.tests.BaseValidatorTest;
 import org.hibernate.beanvalidation.tck.util.TestUtil;
 import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectConstraintViolationMessages;
+import static org.hibernate.beanvalidation.tck.util.TestUtil.webArchiveBuilder;
 
 /**
  * @author Gunnar Morling
  */
 @SpecVersion(spec = "beanvalidation", version = "2.0.0")
-public class ExpressionLanguageMessageInterpolationTest extends Arquillian {
+public class ExpressionLanguageMessageInterpolationTest extends BaseValidatorTest {
 
-	private Validator validator;
 	private Locale originalLocale;
 
 	@Deployment
 	public static WebArchive createTestArchive() {
-		return new WebArchiveBuilder()
+		return webArchiveBuilder()
 				.withTestClass( ExpressionLanguageMessageInterpolationTest.class )
 				.build();
-	}
-
-	@BeforeMethod
-	public void setupValidator() {
-		validator = TestUtil.getValidatorUnderTest();
 	}
 
 	@BeforeMethod
@@ -78,7 +73,7 @@ public class ExpressionLanguageMessageInterpolationTest extends Arquillian {
 			@SpecAssertion(section = "5.3.1.3", id = "b")
 	})
 	public void testInterpolationWithElExpression() {
-		Set<ConstraintViolation<TestBean>> violations = validator.validateProperty( new TestBean(), "firstName" );
+		Set<ConstraintViolation<TestBean>> violations = getValidator().validateProperty( new TestBean(), "firstName" );
 		assertCorrectConstraintViolationMessages( violations, "2" );
 	}
 
@@ -88,7 +83,7 @@ public class ExpressionLanguageMessageInterpolationTest extends Arquillian {
 			@SpecAssertion(section = "5.3.1.3", id = "b")
 	})
 	public void testInterpolationWithSeveralElExpressions() {
-		Set<ConstraintViolation<TestBean>> violations = validator.validateProperty( new TestBean(), "lastName" );
+		Set<ConstraintViolation<TestBean>> violations = getValidator().validateProperty( new TestBean(), "lastName" );
 		assertCorrectConstraintViolationMessages( violations, "2 some text 6" );
 	}
 
@@ -98,28 +93,28 @@ public class ExpressionLanguageMessageInterpolationTest extends Arquillian {
 			@SpecAssertion(section = "5.3.1.3", id = "f"),
 	})
 	public void testInterpolationWithUnknownElExpression() {
-		Set<ConstraintViolation<TestBean>> violations = validator.validateProperty( new TestBean(), "houseNo" );
+		Set<ConstraintViolation<TestBean>> violations = getValidator().validateProperty( new TestBean(), "houseNo" );
 		assertCorrectConstraintViolationMessages( violations, "${unknown}" );
 	}
 
 	@Test
 	@SpecAssertion(section = "5.3.1.3", id = "f")
 	public void testInterpolationWithInvalidElExpression() {
-		Set<ConstraintViolation<TestBean>> violations = validator.validateProperty( new TestBean(), "addition" );
+		Set<ConstraintViolation<TestBean>> violations = getValidator().validateProperty( new TestBean(), "addition" );
 		assertCorrectConstraintViolationMessages( violations, "${1*}" );
 	}
 
 	@Test
 	@SpecAssertion(section = "5.3.1.3", id = "f")
 	public void testInterpolationWithElExpressionThrowingAnException() {
-		Set<ConstraintViolation<TestBean>> violations = validator.validateProperty( new TestBean(), "continent" );
+		Set<ConstraintViolation<TestBean>> violations = getValidator().validateProperty( new TestBean(), "continent" );
 		assertCorrectConstraintViolationMessages( violations, "${validatedValue}" );
 	}
 
 	@Test
 	@SpecAssertion(section = "5.3.1.3", id = "a")
 	public void testInterpolationWithIncompleteElExpression() {
-		Set<ConstraintViolation<TestBean>> violations = validator.validateProperty( new TestBean(), "zipCode" );
+		Set<ConstraintViolation<TestBean>> violations = getValidator().validateProperty( new TestBean(), "zipCode" );
 		assertCorrectConstraintViolationMessages( violations, "${incomplete" );
 	}
 
@@ -129,7 +124,7 @@ public class ExpressionLanguageMessageInterpolationTest extends Arquillian {
 			@SpecAssertion(section = "5.3.1.3", id = "b")
 	})
 	public void testOnlyDollarSignIsSupportedForEnclosingElExpressions() {
-		Set<ConstraintViolation<TestBean>> violations = validator.validateProperty( new TestBean(), "middleName" );
+		Set<ConstraintViolation<TestBean>> violations = getValidator().validateProperty( new TestBean(), "middleName" );
 		assertCorrectConstraintViolationMessages( violations, "#{1+1}" );
 	}
 
@@ -139,7 +134,7 @@ public class ExpressionLanguageMessageInterpolationTest extends Arquillian {
 			@SpecAssertion(section = "5.3.1.3", id = "c")
 	})
 	public void testInterpolationUsingAnnotationAttributesInElExpression() {
-		Set<ConstraintViolation<TestBean>> violations = validator.validateProperty( new TestBean(), "street" );
+		Set<ConstraintViolation<TestBean>> violations = getValidator().validateProperty( new TestBean(), "street" );
 		assertCorrectConstraintViolationMessages( violations, "must be longer than 30" );
 	}
 
@@ -149,7 +144,7 @@ public class ExpressionLanguageMessageInterpolationTest extends Arquillian {
 			@SpecAssertion(section = "5.3.1.3", id = "c")
 	})
 	public void testInterpolationUsingGroupsAndPayloadInElExpression() {
-		Set<ConstraintViolation<TestBean>> violations = validator.validateProperty( new TestBean(), "country" );
+		Set<ConstraintViolation<TestBean>> violations = getValidator().validateProperty( new TestBean(), "country" );
 		assertCorrectConstraintViolationMessages( violations, "groups: Default, payload: CustomPayload" );
 	}
 
@@ -159,7 +154,7 @@ public class ExpressionLanguageMessageInterpolationTest extends Arquillian {
 			@SpecAssertion(section = "5.3.1.3", id = "d")
 	})
 	public void testInterpolationUsingValidatedValueInElExpression() {
-		Set<ConstraintViolation<TestBean>> violations = validator.validateProperty( new TestBean(), "city" );
+		Set<ConstraintViolation<TestBean>> violations = getValidator().validateProperty( new TestBean(), "city" );
 		assertCorrectConstraintViolationMessages( violations, "Foo is not long enough" );
 	}
 
@@ -169,7 +164,7 @@ public class ExpressionLanguageMessageInterpolationTest extends Arquillian {
 			@SpecAssertion(section = "5.3.1.3", id = "e")
 	})
 	public void testInterpolationUsingFormatterInElExpression() {
-		Set<ConstraintViolation<TestBean>> violations = validator.validateProperty( new TestBean(), "longitude" );
+		Set<ConstraintViolation<TestBean>> violations = getValidator().validateProperty( new TestBean(), "longitude" );
 		assertCorrectConstraintViolationMessages( violations, "98.12 must be larger than 100" );
 	}
 
@@ -179,7 +174,7 @@ public class ExpressionLanguageMessageInterpolationTest extends Arquillian {
 			@SpecAssertion(section = "5.3.1.3", id = "e")
 	})
 	public void testInterpolationUsingFormatterWithSeveralObjectsInElExpression() {
-		Set<ConstraintViolation<TestBean>> violations = validator.validateProperty( new TestBean(), "latitude" );
+		Set<ConstraintViolation<TestBean>> violations = getValidator().validateProperty( new TestBean(), "latitude" );
 		assertCorrectConstraintViolationMessages( violations, "98.12 (that is, 98.1235) must be larger than 100" );
 	}
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/metadata/BeanDescriptorTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/metadata/BeanDescriptorTest.java
@@ -12,7 +12,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import javax.validation.Validator;
 import javax.validation.metadata.BeanDescriptor;
 import javax.validation.metadata.ConstructorDescriptor;
 import javax.validation.metadata.MethodDescriptor;
@@ -21,18 +20,16 @@ import javax.validation.metadata.ParameterDescriptor;
 import javax.validation.metadata.PropertyDescriptor;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import org.hibernate.beanvalidation.tck.util.TestUtil;
-import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
+import org.hibernate.beanvalidation.tck.tests.BaseValidatorTest;
 
 import static org.hibernate.beanvalidation.tck.util.TestUtil.asSet;
+import static org.hibernate.beanvalidation.tck.util.TestUtil.webArchiveBuilder;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -43,13 +40,11 @@ import static org.testng.Assert.assertTrue;
  * @author Hardy Ferentschik
  */
 @SpecVersion(spec = "beanvalidation", version = "2.0.0")
-public class BeanDescriptorTest extends Arquillian {
-
-	private Validator validator;
+public class BeanDescriptorTest extends BaseValidatorTest {
 
 	@Deployment
 	public static WebArchive createTestArchive() {
-		return new WebArchiveBuilder()
+		return webArchiveBuilder()
 				.withTestClass( BeanDescriptorTest.class )
 				.withClasses(
 						Customer.class,
@@ -68,15 +63,10 @@ public class BeanDescriptorTest extends Arquillian {
 				.build();
 	}
 
-	@BeforeMethod
-	private void setupValidator() {
-		validator = TestUtil.getValidatorUnderTest();
-	}
-
 	@Test
 	@SpecAssertion(section = "6.2", id = "a")
 	public void testGetElementClassReturnsBeanClass() {
-		BeanDescriptor beanDescriptor = validator.getConstraintsForClass( Customer.class );
+		BeanDescriptor beanDescriptor = getValidator().getConstraintsForClass( Customer.class );
 		assertEquals( beanDescriptor.getElementClass(), Customer.class, "Wrong element class" );
 	}
 
@@ -86,7 +76,7 @@ public class BeanDescriptorTest extends Arquillian {
 			@SpecAssertion(section = "6.3", id = "a")
 	})
 	public void testIsBeanConstrainedDueToValidAnnotation() {
-		BeanDescriptor beanDescriptor = validator.getConstraintsForClass( Customer.class );
+		BeanDescriptor beanDescriptor = getValidator().getConstraintsForClass( Customer.class );
 
 		// constraint via @Valid
 		assertFalse(
@@ -106,7 +96,7 @@ public class BeanDescriptorTest extends Arquillian {
 	})
 	public void testIsBeanConstrainedDueToConstraintOnEntity() {
 		// constraint hosted on bean itself
-		BeanDescriptor beanDescriptor = validator.getConstraintsForClass( Account.class );
+		BeanDescriptor beanDescriptor = getValidator().getConstraintsForClass( Account.class );
 		assertTrue(
 				beanDescriptor.hasConstraints(),
 				"There should be direct constraints on the specified bean."
@@ -124,7 +114,7 @@ public class BeanDescriptorTest extends Arquillian {
 	})
 	public void testIsBeanConstrainedDueToConstraintProperty() {
 		// constraint on bean property
-		BeanDescriptor beanDescriptor = validator.getConstraintsForClass( Order.class );
+		BeanDescriptor beanDescriptor = getValidator().getConstraintsForClass( Order.class );
 		assertFalse(
 				beanDescriptor.hasConstraints(),
 				"There should be no direct constraints on the specified bean."
@@ -142,7 +132,7 @@ public class BeanDescriptorTest extends Arquillian {
 	})
 	public void testIsBeanConstrainedDueToConstraintOnInterface() {
 		// constraint on implemented interface
-		BeanDescriptor beanDescriptor = validator.getConstraintsForClass( Man.class );
+		BeanDescriptor beanDescriptor = getValidator().getConstraintsForClass( Man.class );
 		assertFalse(
 				beanDescriptor.hasConstraints(),
 				"There should be no direct constraints on the specified bean."
@@ -159,7 +149,7 @@ public class BeanDescriptorTest extends Arquillian {
 			@SpecAssertion(section = "6.3", id = "a")
 	})
 	public void testUnconstrainedClass() {
-		BeanDescriptor beanDescriptor = validator.getConstraintsForClass( UnconstraintEntity.class );
+		BeanDescriptor beanDescriptor = getValidator().getConstraintsForClass( UnconstraintEntity.class );
 		assertFalse(
 				beanDescriptor.hasConstraints(),
 				"There should be no direct constraints on the specified bean."
@@ -173,7 +163,7 @@ public class BeanDescriptorTest extends Arquillian {
 			@SpecAssertion(section = "6.3", id = "b")
 	})
 	public void testGetConstraintsForConstrainedProperty() {
-		BeanDescriptor beanDescriptor = validator.getConstraintsForClass( Order.class );
+		BeanDescriptor beanDescriptor = getValidator().getConstraintsForClass( Order.class );
 		PropertyDescriptor propertyDescriptor = beanDescriptor.getConstraintsForProperty(
 				"orderNumber"
 		);
@@ -190,7 +180,7 @@ public class BeanDescriptorTest extends Arquillian {
 			@SpecAssertion(section = "6.4", id = "a")
 	})
 	public void testGetConstraintsForUnConstrainedProperty() {
-		BeanDescriptor beanDescriptor = validator.getConstraintsForClass( Customer.class );
+		BeanDescriptor beanDescriptor = getValidator().getConstraintsForClass( Customer.class );
 		PropertyDescriptor propertyDescriptor = beanDescriptor.getConstraintsForProperty(
 				"orderList"
 		);
@@ -208,7 +198,7 @@ public class BeanDescriptorTest extends Arquillian {
 			@SpecAssertion(section = "6.3", id = "b")
 	})
 	public void testGetConstraintsForNonExistingProperty() {
-		BeanDescriptor beanDescriptor = validator.getConstraintsForClass( Order.class );
+		BeanDescriptor beanDescriptor = getValidator().getConstraintsForClass( Order.class );
 		assertNull(
 				beanDescriptor.getConstraintsForProperty( "foobar" ),
 				"There should be no descriptor"
@@ -221,7 +211,7 @@ public class BeanDescriptorTest extends Arquillian {
 			@SpecAssertion(section = "6.3", id = "d")
 	})
 	public void testGetConstrainedProperties() {
-		BeanDescriptor beanDescriptor = validator.getConstraintsForClass( Order.class );
+		BeanDescriptor beanDescriptor = getValidator().getConstraintsForClass( Order.class );
 		Set<PropertyDescriptor> constraintProperties = beanDescriptor.getConstrainedProperties();
 		assertEquals( constraintProperties.size(), 1, "There should be only one property" );
 		boolean hasOrderNumber = false;
@@ -237,7 +227,7 @@ public class BeanDescriptorTest extends Arquillian {
 			@SpecAssertion(section = "6.3", id = "d")
 	})
 	public void testGetConstrainedPropertiesForUnconstrainedEntity() {
-		BeanDescriptor beanDescriptor = validator.getConstraintsForClass( UnconstraintEntity.class );
+		BeanDescriptor beanDescriptor = getValidator().getConstraintsForClass( UnconstraintEntity.class );
 		Set<PropertyDescriptor> constraintProperties = beanDescriptor.getConstrainedProperties();
 		assertEquals( constraintProperties.size(), 0, "We should get the empty set." );
 	}
@@ -245,7 +235,7 @@ public class BeanDescriptorTest extends Arquillian {
 	@Test(expectedExceptions = IllegalArgumentException.class)
 	@SpecAssertion(section = "6.3", id = "c")
 	public void testGetConstraintsForNullProperty() {
-		BeanDescriptor beanDescriptor = validator.getConstraintsForClass( Order.class );
+		BeanDescriptor beanDescriptor = getValidator().getConstraintsForClass( Order.class );
 		beanDescriptor.getConstraintsForProperty( null );
 	}
 
@@ -294,7 +284,7 @@ public class BeanDescriptorTest extends Arquillian {
 	@Test
 	@SpecAssertion(section = "6.3", id = "e")
 	public void testGetConstraintsForNonExistingMethod() {
-		BeanDescriptor beanDescriptor = validator.getConstraintsForClass( CustomerService.class );
+		BeanDescriptor beanDescriptor = getValidator().getConstraintsForClass( CustomerService.class );
 		MethodDescriptor methodDescriptor = beanDescriptor.getConstraintsForMethod( "foo" );
 		assertNull( methodDescriptor, "Descriptor should be null" );
 	}
@@ -302,14 +292,14 @@ public class BeanDescriptorTest extends Arquillian {
 	@Test(expectedExceptions = IllegalArgumentException.class)
 	@SpecAssertion(section = "6.3", id = "e")
 	public void testGetConstraintsForNullMethod() {
-		BeanDescriptor beanDescriptor = validator.getConstraintsForClass( CustomerService.class );
+		BeanDescriptor beanDescriptor = getValidator().getConstraintsForClass( CustomerService.class );
 		beanDescriptor.getConstraintsForMethod( null );
 	}
 
 	@Test
 	@SpecAssertion(section = "6.3", id = "f")
 	public void testGetConstrainedMethodsTypeNON_GETTER() {
-		BeanDescriptor beanDescriptor = validator.getConstraintsForClass( CustomerService.class );
+		BeanDescriptor beanDescriptor = getValidator().getConstraintsForClass( CustomerService.class );
 		Set<MethodDescriptor> methodDescriptors = beanDescriptor.getConstrainedMethods( MethodType.NON_GETTER );
 
 		List<String> actualMethodNames = new ArrayList<String>();
@@ -337,7 +327,7 @@ public class BeanDescriptorTest extends Arquillian {
 	@Test
 	@SpecAssertion(section = "6.3", id = "f")
 	public void testGetConstrainedMethodsTypeGETTER() {
-		BeanDescriptor beanDescriptor = validator.getConstraintsForClass( CustomerService.class );
+		BeanDescriptor beanDescriptor = getValidator().getConstraintsForClass( CustomerService.class );
 		Set<MethodDescriptor> methodDescriptors = beanDescriptor.getConstrainedMethods( MethodType.GETTER );
 
 		assertEquals( methodDescriptors.size(), 1 );
@@ -347,7 +337,7 @@ public class BeanDescriptorTest extends Arquillian {
 	@Test
 	@SpecAssertion(section = "6.3", id = "f")
 	public void testGetConstrainedMethodsTypesGETTERAndNON_GETTER() {
-		BeanDescriptor beanDescriptor = validator.getConstraintsForClass( CustomerService.class );
+		BeanDescriptor beanDescriptor = getValidator().getConstraintsForClass( CustomerService.class );
 		Set<MethodDescriptor> methodDescriptors = beanDescriptor.getConstrainedMethods(
 				MethodType.GETTER,
 				MethodType.NON_GETTER
@@ -379,7 +369,7 @@ public class BeanDescriptorTest extends Arquillian {
 	@Test
 	@SpecAssertion(section = "6.3", id = "f")
 	public void testGetConstrainedMethodsForUnconstrainedEntity() {
-		BeanDescriptor beanDescriptor = validator.getConstraintsForClass( UnconstraintEntity.class );
+		BeanDescriptor beanDescriptor = getValidator().getConstraintsForClass( UnconstraintEntity.class );
 		Set<MethodDescriptor> methodDescriptors = beanDescriptor.getConstrainedMethods(
 				MethodType.GETTER,
 				MethodType.NON_GETTER
@@ -432,7 +422,7 @@ public class BeanDescriptorTest extends Arquillian {
 	@Test
 	@SpecAssertion(section = "6.3", id = "g")
 	public void testGetConstraintsForNonExistingConstructorConstructor() {
-		BeanDescriptor beanDescriptor = validator.getConstraintsForClass( CustomerService.class );
+		BeanDescriptor beanDescriptor = getValidator().getConstraintsForClass( CustomerService.class );
 		ConstructorDescriptor constructorDescriptor = beanDescriptor.getConstraintsForConstructor(
 				Short.class
 		);
@@ -442,7 +432,7 @@ public class BeanDescriptorTest extends Arquillian {
 	@Test
 	@SpecAssertion(section = "6.3", id = "h")
 	public void testGetConstrainedConstructors() {
-		BeanDescriptor beanDescriptor = validator.getConstraintsForClass( CustomerService.class );
+		BeanDescriptor beanDescriptor = getValidator().getConstraintsForClass( CustomerService.class );
 		Set<ConstructorDescriptor> constructorDescriptors = beanDescriptor.getConstrainedConstructors();
 
 		Set<List<Class<?>>> actualParameterTypes = getParameterTypes( constructorDescriptors );
@@ -463,7 +453,7 @@ public class BeanDescriptorTest extends Arquillian {
 	@Test
 	@SpecAssertion(section = "6.3", id = "h")
 	public void testGetConstrainedConstructorsForUnconstrainedEntity() {
-		BeanDescriptor beanDescriptor = validator.getConstraintsForClass( UnconstraintEntity.class );
+		BeanDescriptor beanDescriptor = getValidator().getConstraintsForClass( UnconstraintEntity.class );
 		Set<ConstructorDescriptor> constructorDescriptors = beanDescriptor.getConstrainedConstructors();
 		assertEquals( constructorDescriptors.size(), 0, "We should get the empty set." );
 	}

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ExecutableValidationIgnoresValidatedExecutableAnnotationSettingsTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ExecutableValidationIgnoresValidatedExecutableAnnotationSettingsTest.java
@@ -12,51 +12,42 @@ import java.util.Set;
 import javax.validation.ConstraintViolation;
 import javax.validation.ElementKind;
 import javax.validation.constraints.NotNull;
-import javax.validation.executable.ExecutableValidator;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.constraint.ValidLineItem;
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.constraint.ValidWarehouseItem;
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.model.LineItem;
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.model.WarehouseItem;
+import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
 import org.hibernate.beanvalidation.tck.util.TestUtil;
-import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectConstraintTypes;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectPathNodeKinds;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectPathNodeNames;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.kinds;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.names;
+import static org.hibernate.beanvalidation.tck.util.TestUtil.webArchiveBuilder;
 
 /**
  * @author Gunnar Morling
  */
 @SpecVersion(spec = "beanvalidation", version = "2.0.0")
-public class ExecutableValidationIgnoresValidatedExecutableAnnotationSettingsTest extends Arquillian {
-
-	private ExecutableValidator executableValidator;
+public class ExecutableValidationIgnoresValidatedExecutableAnnotationSettingsTest extends BaseExecutableValidatorTest {
 
 	@Deployment
 	public static WebArchive createTestArchive() {
-		return new WebArchiveBuilder()
+		return webArchiveBuilder()
 				.withTestClass( ExecutableValidationIgnoresValidatedExecutableAnnotationSettingsTest.class )
 				.withClass( LineItem.class )
 				.withClass( WarehouseItem.class )
 				.withClass( ValidLineItem.class )
 				.withClass( ValidWarehouseItem.class )
 				.build();
-	}
-
-	@BeforeMethod
-	public void setupValidator() {
-		executableValidator = TestUtil.getValidatorUnderTest().forExecutables();
 	}
 
 	@Test
@@ -68,7 +59,7 @@ public class ExecutableValidationIgnoresValidatedExecutableAnnotationSettingsTes
 		Method method = LineItem.class.getMethod( methodName, String.class );
 		Object[] parameterValues = new Object[] { null };
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -86,7 +77,7 @@ public class ExecutableValidationIgnoresValidatedExecutableAnnotationSettingsTes
 		Constructor<LineItem> constructor = LineItem.class.getConstructor( String.class );
 		Object[] parameterValues = new Object[] { null };
 
-		Set<ConstraintViolation<LineItem>> violations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<LineItem>> violations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
@@ -105,7 +96,7 @@ public class ExecutableValidationIgnoresValidatedExecutableAnnotationSettingsTes
 		Method method = LineItem.class.getMethod( methodName, String.class );
 		Object returnValue = null;
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
@@ -123,7 +114,7 @@ public class ExecutableValidationIgnoresValidatedExecutableAnnotationSettingsTes
 		Constructor<LineItem> constructor = LineItem.class.getConstructor( String.class );
 		LineItem createdObject = new LineItem( null );
 
-		Set<ConstraintViolation<LineItem>> violations = executableValidator.validateConstructorReturnValue(
+		Set<ConstraintViolation<LineItem>> violations = getExecutableValidator().validateConstructorReturnValue(
 				constructor,
 				createdObject
 		);
@@ -142,7 +133,7 @@ public class ExecutableValidationIgnoresValidatedExecutableAnnotationSettingsTes
 		Method method = WarehouseItem.class.getMethod( methodName, String.class );
 		Object[] parameterValues = new Object[] { null };
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -160,7 +151,7 @@ public class ExecutableValidationIgnoresValidatedExecutableAnnotationSettingsTes
 		Constructor<WarehouseItem> constructor = WarehouseItem.class.getConstructor( String.class );
 		Object[] parameterValues = new Object[] { null };
 
-		Set<ConstraintViolation<WarehouseItem>> violations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<WarehouseItem>> violations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
@@ -179,7 +170,7 @@ public class ExecutableValidationIgnoresValidatedExecutableAnnotationSettingsTes
 		Method method = WarehouseItem.class.getMethod( methodName, String.class );
 		Object returnValue = null;
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
@@ -197,7 +188,7 @@ public class ExecutableValidationIgnoresValidatedExecutableAnnotationSettingsTes
 		Constructor<WarehouseItem> constructor = WarehouseItem.class.getConstructor( String.class );
 		WarehouseItem createdObject = new WarehouseItem( null );
 
-		Set<ConstraintViolation<WarehouseItem>> violations = executableValidator.validateConstructorReturnValue(
+		Set<ConstraintViolation<WarehouseItem>> violations = getExecutableValidator().validateConstructorReturnValue(
 				constructor,
 				createdObject
 		);

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ExecutableValidationIgnoresValidatedExecutableXmlSettingsTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ExecutableValidationIgnoresValidatedExecutableXmlSettingsTest.java
@@ -14,49 +14,40 @@ import javax.validation.ConstraintViolation;
 import javax.validation.ElementKind;
 import javax.validation.Validation;
 import javax.validation.constraints.NotNull;
-import javax.validation.executable.ExecutableValidator;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.constraint.ValidStockItem;
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.model.StockItem;
+import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
 import org.hibernate.beanvalidation.tck.util.TestUtil;
-import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectConstraintTypes;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectPathNodeKinds;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectPathNodeNames;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.kinds;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.names;
+import static org.hibernate.beanvalidation.tck.util.TestUtil.webArchiveBuilder;
 import static org.testng.Assert.assertEquals;
 
 /**
  * @author Gunnar Morling
  */
 @SpecVersion(spec = "beanvalidation", version = "2.0.0")
-public class ExecutableValidationIgnoresValidatedExecutableXmlSettingsTest extends Arquillian {
-
-	private ExecutableValidator executableValidator;
+public class ExecutableValidationIgnoresValidatedExecutableXmlSettingsTest extends BaseExecutableValidatorTest {
 
 	@Deployment
 	public static WebArchive createTestArchive() {
-		return new WebArchiveBuilder()
+		return webArchiveBuilder()
 				.withTestClass( ExecutableValidationIgnoresValidatedExecutableXmlSettingsTest.class )
 				.withClass( StockItem.class )
 				.withClass( ValidStockItem.class )
 				.withValidationXml( "validation-ExecutableValidationIgnoresValidatedExecutableXmlSettingsTest.xml" )
 				.build();
-	}
-
-	@BeforeMethod
-	public void setupValidator() {
-		executableValidator = TestUtil.getValidatorUnderTest().forExecutables();
 	}
 
 	@Test
@@ -72,7 +63,7 @@ public class ExecutableValidationIgnoresValidatedExecutableXmlSettingsTest exten
 		Method method = StockItem.class.getMethod( methodName, String.class );
 		Object[] parameterValues = new Object[] { null };
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -95,7 +86,7 @@ public class ExecutableValidationIgnoresValidatedExecutableXmlSettingsTest exten
 		Constructor<StockItem> constructor = StockItem.class.getConstructor( String.class );
 		Object[] parameterValues = new Object[] { null };
 
-		Set<ConstraintViolation<StockItem>> violations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<StockItem>> violations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
@@ -119,7 +110,7 @@ public class ExecutableValidationIgnoresValidatedExecutableXmlSettingsTest exten
 		Method method = StockItem.class.getMethod( methodName, String.class );
 		Object returnValue = null;
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
@@ -142,7 +133,7 @@ public class ExecutableValidationIgnoresValidatedExecutableXmlSettingsTest exten
 		Constructor<StockItem> constructor = StockItem.class.getConstructor( String.class );
 		StockItem createdObject = new StockItem( null );
 
-		Set<ConstraintViolation<StockItem>> violations = executableValidator.validateConstructorReturnValue(
+		Set<ConstraintViolation<StockItem>> violations = getExecutableValidator().validateConstructorReturnValue(
 				constructor,
 				createdObject
 		);

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/MethodValidationTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/MethodValidationTest.java
@@ -15,15 +15,12 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
-import javax.validation.executable.ExecutableValidator;
 import javax.validation.groups.Default;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.constraint.MyCrossParameterConstraint;
@@ -39,6 +36,7 @@ import org.hibernate.beanvalidation.tck.tests.methodvalidation.service.OrderServ
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.service.OrderService.OrderServiceSequence;
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.service.OrderServiceImpl;
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.service.OrderServiceWithRedefinedDefaultGroupSequence;
+import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
 import org.hibernate.beanvalidation.tck.util.TestUtil;
 import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
@@ -48,29 +46,23 @@ import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectPathNo
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectPathNodeNames;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.kinds;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.names;
+import static org.hibernate.beanvalidation.tck.util.TestUtil.webArchiveBuilder;
 
 /**
  * @author Gunnar Morling
  */
 @SpecVersion(spec = "beanvalidation", version = "2.0.0")
-public class MethodValidationTest extends Arquillian {
-
-	private ExecutableValidator executableValidator;
+public class MethodValidationTest extends BaseExecutableValidatorTest {
 
 	@Deployment
 	public static WebArchive createTestArchive() {
-		return new WebArchiveBuilder()
+		return webArchiveBuilder()
 				.withTestClass( ValidateConstructorParametersTest.class )
 				.withPackage( MyCrossParameterConstraint.class.getPackage() )
 				.withPackage( ExtendedOrderService.class.getPackage() )
 				.withClass( Item.class )
 				.withClass( Order.class )
 				.build();
-	}
-
-	@BeforeMethod
-	public void setupValidator() {
-		executableValidator = TestUtil.getValidatorUnderTest().forExecutables();
 	}
 
 	@Test
@@ -88,7 +80,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 		Object[] parameterValues = new Object[] { null, new Item( "" ), 0 };
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -131,7 +123,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 		Object[] parameterValues = new Object[] { null, new Item( "" ), 0 };
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -175,7 +167,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 		Object[] parameterValues = new Object[] { null, new Item( "" ), 0 };
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -218,7 +210,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 		Object[] parameterValues = new Object[] { null, new Item( "" ), 0 };
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues,
@@ -242,7 +234,7 @@ public class MethodValidationTest extends Arquillian {
 				kinds( ElementKind.METHOD, ElementKind.PARAMETER )
 		);
 
-		violations = executableValidator.validateParameters(
+		violations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -280,7 +272,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 		Object[] parameterValues = new Object[] { null, new Item( "" ), 0 };
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues,
@@ -309,7 +301,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 		Object[] parameterValues = new Object[] { null, new Item( "" ), (short) 0 };
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues,
@@ -353,7 +345,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 		Object[] parameterValues = new Object[] { null, new Item( "" ), (byte) 0 };
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues,
@@ -375,7 +367,7 @@ public class MethodValidationTest extends Arquillian {
 
 		parameterValues = new Object[] { "Bob", new Item( "BV Specification" ), (byte) 0 };
 
-		violations = executableValidator.validateParameters(
+		violations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues,
@@ -410,7 +402,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 		Object[] parameterValues = new Object[] { null, new Item( "" ), (byte) 0 };
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -432,7 +424,7 @@ public class MethodValidationTest extends Arquillian {
 
 		parameterValues = new Object[] { "Bob", new Item( "" ), (byte) 0 };
 
-		violations = executableValidator.validateParameters(
+		violations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -473,7 +465,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 		Object[] parameterValues = new Object[] { null, new Item( "" ), 0 };
 
-		Set<ConstraintViolation<OrderService>> violations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<OrderService>> violations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
@@ -512,7 +504,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 		Object[] parameterValues = new Object[] { null, new Item( "" ), 0 };
 
-		Set<ConstraintViolation<ExtendedOrderService>> violations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<ExtendedOrderService>> violations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
@@ -532,7 +524,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 		Object[] parameterValues = new Object[] { null, new Item( "" ), 0 };
 
-		Set<ConstraintViolation<OrderService>> violations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<OrderService>> violations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues,
 				Basic.class
@@ -555,7 +547,7 @@ public class MethodValidationTest extends Arquillian {
 				kinds( ElementKind.CONSTRUCTOR, ElementKind.PARAMETER )
 		);
 
-		violations = executableValidator.validateConstructorParameters(
+		violations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
@@ -590,7 +582,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 		Object[] parameterValues = new Object[] { null, new Item( "" ), 0 };
 
-		Set<ConstraintViolation<OrderService>> violations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<OrderService>> violations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues,
 				Basic.class
@@ -616,7 +608,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 		Object[] parameterValues = new Object[] { null, new Item( "" ), (short) 0 };
 
-		Set<ConstraintViolation<OrderService>> violations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<OrderService>> violations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues,
 				Basic.class, Default.class
@@ -657,7 +649,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 		Object[] parameterValues = new Object[] { null, new Item( "" ), (byte) 0 };
 
-		Set<ConstraintViolation<OrderService>> violations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<OrderService>> violations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues,
 				OrderServiceSequence.class
@@ -678,7 +670,7 @@ public class MethodValidationTest extends Arquillian {
 
 		parameterValues = new Object[] { "Bob", new Item( "BV Specification" ), (byte) 0 };
 
-		violations = executableValidator.validateConstructorParameters(
+		violations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues,
 				OrderServiceSequence.class
@@ -711,7 +703,7 @@ public class MethodValidationTest extends Arquillian {
 				);
 		Object[] parameterValues = new Object[] { null, new Item( "" ), (byte) 0 };
 
-		Set<ConstraintViolation<OrderServiceWithRedefinedDefaultGroupSequence>> violations = executableValidator
+		Set<ConstraintViolation<OrderServiceWithRedefinedDefaultGroupSequence>> violations = getExecutableValidator()
 				.validateConstructorParameters(
 						constructor,
 						parameterValues
@@ -733,7 +725,7 @@ public class MethodValidationTest extends Arquillian {
 
 		parameterValues = new Object[] { "Bob", new Item( "" ), (byte) 0 };
 
-		violations = executableValidator.validateConstructorParameters(
+		violations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
@@ -775,7 +767,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 		Object returnValue = new Order( "" );
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
@@ -812,7 +804,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 		Object returnValue = new Order( "" );
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
@@ -853,7 +845,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 		Object returnValue = new Order( "" );
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
@@ -893,7 +885,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 		Object returnValue = new Order( "" );
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue,
@@ -914,7 +906,7 @@ public class MethodValidationTest extends Arquillian {
 				kinds( ElementKind.METHOD, ElementKind.RETURN_VALUE )
 		);
 
-		violations = executableValidator.validateReturnValue(
+		violations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
@@ -952,7 +944,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 		Object returnValue = new Order( "" );
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue,
@@ -981,7 +973,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 		Object returnValue = new Order( "" );
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue,
@@ -1016,7 +1008,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 		Object returnValue = new Order( "" );
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue,
@@ -1038,7 +1030,7 @@ public class MethodValidationTest extends Arquillian {
 
 		returnValue = new Order( "BV Specification" );
 
-		violations = executableValidator.validateReturnValue(
+		violations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue,
@@ -1071,7 +1063,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 		Object returnValue = new Order( "" );
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
@@ -1093,7 +1085,7 @@ public class MethodValidationTest extends Arquillian {
 
 		returnValue = new Order( "valid" );
 
-		violations = executableValidator.validateReturnValue(
+		violations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
@@ -1127,7 +1119,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 		OrderService returnValue = new OrderService( "" );
 
-		Set<ConstraintViolation<OrderService>> violations = executableValidator.validateConstructorReturnValue(
+		Set<ConstraintViolation<OrderService>> violations = getExecutableValidator().validateConstructorReturnValue(
 				constructor,
 				returnValue
 		);
@@ -1162,7 +1154,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 		ExtendedOrderService returnValue = new ExtendedOrderService();
 
-		Set<ConstraintViolation<ExtendedOrderService>> violations = executableValidator.validateConstructorReturnValue(
+		Set<ConstraintViolation<ExtendedOrderService>> violations = getExecutableValidator().validateConstructorReturnValue(
 				constructor,
 				returnValue
 		);
@@ -1193,7 +1185,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 		OrderService returnValue = new OrderService( "" );
 
-		Set<ConstraintViolation<OrderService>> violations = executableValidator.validateConstructorReturnValue(
+		Set<ConstraintViolation<OrderService>> violations = getExecutableValidator().validateConstructorReturnValue(
 				constructor,
 				returnValue,
 				Basic.class
@@ -1213,7 +1205,7 @@ public class MethodValidationTest extends Arquillian {
 				kinds( ElementKind.CONSTRUCTOR, ElementKind.RETURN_VALUE )
 		);
 
-		violations = executableValidator.validateConstructorReturnValue(
+		violations = getExecutableValidator().validateConstructorReturnValue(
 				constructor,
 				returnValue
 		);
@@ -1248,7 +1240,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 		OrderService returnValue = new OrderService( "" );
 
-		Set<ConstraintViolation<OrderService>> violations = executableValidator.validateConstructorReturnValue(
+		Set<ConstraintViolation<OrderService>> violations = getExecutableValidator().validateConstructorReturnValue(
 				constructor,
 				returnValue,
 				Basic.class
@@ -1274,7 +1266,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 		OrderService returnValue = new OrderService( "" );
 
-		Set<ConstraintViolation<OrderService>> violations = executableValidator.validateConstructorReturnValue(
+		Set<ConstraintViolation<OrderService>> violations = getExecutableValidator().validateConstructorReturnValue(
 				constructor,
 				returnValue,
 				Basic.class, Default.class
@@ -1306,7 +1298,7 @@ public class MethodValidationTest extends Arquillian {
 		);
 		OrderService returnValue = new OrderService( "" );
 
-		Set<ConstraintViolation<OrderService>> violations = executableValidator.validateConstructorReturnValue(
+		Set<ConstraintViolation<OrderService>> violations = getExecutableValidator().validateConstructorReturnValue(
 				constructor,
 				returnValue,
 				OrderServiceSequence.class
@@ -1327,7 +1319,7 @@ public class MethodValidationTest extends Arquillian {
 
 		returnValue = new OrderService( "valid order service" );
 
-		violations = executableValidator.validateConstructorReturnValue(
+		violations = getExecutableValidator().validateConstructorReturnValue(
 				constructor,
 				returnValue,
 				OrderServiceSequence.class
@@ -1361,7 +1353,7 @@ public class MethodValidationTest extends Arquillian {
 				""
 		);
 
-		Set<ConstraintViolation<OrderServiceWithRedefinedDefaultGroupSequence>> violations = executableValidator
+		Set<ConstraintViolation<OrderServiceWithRedefinedDefaultGroupSequence>> violations = getExecutableValidator()
 				.validateConstructorReturnValue(
 						constructor,
 						returnValue
@@ -1382,7 +1374,7 @@ public class MethodValidationTest extends Arquillian {
 
 		returnValue = new OrderServiceWithRedefinedDefaultGroupSequence( "valid" );
 
-		violations = executableValidator.validateConstructorReturnValue(
+		violations = getExecutableValidator().validateConstructorReturnValue(
 				constructor,
 				returnValue
 		);

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ValidateConstructorParametersTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ValidateConstructorParametersTest.java
@@ -15,15 +15,12 @@ import javax.validation.ValidationException;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
-import javax.validation.executable.ExecutableValidator;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.constraint.MyCrossParameterConstraint;
@@ -33,6 +30,7 @@ import org.hibernate.beanvalidation.tck.tests.methodvalidation.model.OrderLine;
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.model.User;
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.model.User.Basic;
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.model.User.Extended;
+import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
 import org.hibernate.beanvalidation.tck.util.TestUtil;
 import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
@@ -42,6 +40,7 @@ import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectPathNo
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectPathNodeNames;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.kinds;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.names;
+import static org.hibernate.beanvalidation.tck.util.TestUtil.webArchiveBuilder;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
@@ -49,13 +48,11 @@ import static org.testng.Assert.assertNull;
  * @author Gunnar Morling
  */
 @SpecVersion(spec = "beanvalidation", version = "2.0.0")
-public class ValidateConstructorParametersTest extends Arquillian {
-
-	private ExecutableValidator executableValidator;
+public class ValidateConstructorParametersTest extends BaseExecutableValidatorTest {
 
 	@Deployment
 	public static WebArchive createTestArchive() {
-		return new WebArchiveBuilder()
+		return webArchiveBuilder()
 				.withTestClass( ValidateConstructorParametersTest.class )
 				.withPackage( MyCrossParameterConstraint.class.getPackage() )
 				.withClass( Address.class )
@@ -63,11 +60,6 @@ public class ValidateConstructorParametersTest extends Arquillian {
 				.withClass( OrderLine.class )
 				.withClass( User.class )
 				.build();
-	}
-
-	@BeforeMethod
-	public void setupValidator() {
-		executableValidator = TestUtil.getValidatorUnderTest().forExecutables();
 	}
 
 	@Test
@@ -86,7 +78,7 @@ public class ValidateConstructorParametersTest extends Arquillian {
 		String arg0 = "B";
 		Object[] parameterValues = new Object[] { arg0 };
 
-		Set<ConstraintViolation<User>> violations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<User>> violations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
@@ -116,7 +108,7 @@ public class ValidateConstructorParametersTest extends Arquillian {
 		Constructor<User> constructor = User.class.getConstructor( String.class, String.class );
 		Object[] parameterValues = new Object[] { null, null };
 
-		Set<ConstraintViolation<User>> violations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<User>> violations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
@@ -142,7 +134,7 @@ public class ValidateConstructorParametersTest extends Arquillian {
 		);
 		Object[] parameterValues = new Object[] { null, "S" };
 
-		Set<ConstraintViolation<User>> violations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<User>> violations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
@@ -168,7 +160,7 @@ public class ValidateConstructorParametersTest extends Arquillian {
 		Constructor<User> constructor = User.class.getConstructor( String.class, int.class );
 		Object[] parameterValues = new Object[] { "S", 0 };
 
-		Set<ConstraintViolation<User>> violations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<User>> violations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
@@ -194,7 +186,7 @@ public class ValidateConstructorParametersTest extends Arquillian {
 		Constructor<User> constructor = User.class.getConstructor( CharSequence.class );
 		Object[] parameterValues = new Object[] { "S" };
 
-		Set<ConstraintViolation<User>> violations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<User>> violations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
@@ -224,7 +216,7 @@ public class ValidateConstructorParametersTest extends Arquillian {
 		);
 		Object[] parameterValues = new Object[] { null, null, null };
 
-		Set<ConstraintViolation<User>> violations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<User>> violations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
@@ -257,7 +249,7 @@ public class ValidateConstructorParametersTest extends Arquillian {
 		);
 		Object[] parameterValues = new Object[] { "Bob", "Smith" };
 
-		Set<ConstraintViolation<User>> violations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<User>> violations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
@@ -271,14 +263,14 @@ public class ValidateConstructorParametersTest extends Arquillian {
 		Constructor<User> constructor = User.class.getConstructor( String.class, long.class );
 		Object[] parameterValues = new Object[] { "S", 0l };
 
-		Set<ConstraintViolation<User>> violations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<User>> violations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
 
 		assertCorrectNumberOfViolations( violations, 0 );
 
-		violations = executableValidator.validateConstructorParameters(
+		violations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues,
 				Extended.class
@@ -298,14 +290,14 @@ public class ValidateConstructorParametersTest extends Arquillian {
 		);
 		Object[] parameterValues = new Object[] { null, null };
 
-		Set<ConstraintViolation<User>> violations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<User>> violations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
 
 		assertCorrectNumberOfViolations( violations, 0 );
 
-		violations = executableValidator.validateConstructorParameters(
+		violations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues,
 				Extended.class
@@ -326,14 +318,14 @@ public class ValidateConstructorParametersTest extends Arquillian {
 		);
 		Object[] parameterValues = new Object[] { null, "S", null };
 
-		Set<ConstraintViolation<User>> violations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<User>> violations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
 
 		assertCorrectNumberOfViolations( violations, 0 );
 
-		violations = executableValidator.validateConstructorParameters(
+		violations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues,
 				Basic.class,
@@ -361,7 +353,7 @@ public class ValidateConstructorParametersTest extends Arquillian {
 		Constructor<Address> constructor = Address.class.getConstructor( String.class );
 		Object[] parameterValues = new Object[] { "S" };
 
-		executableValidator.validateConstructorParameters( constructor, parameterValues );
+		getExecutableValidator().validateConstructorParameters( constructor, parameterValues );
 	}
 
 	@Test(expectedExceptions = IllegalArgumentException.class)
@@ -370,7 +362,7 @@ public class ValidateConstructorParametersTest extends Arquillian {
 		Constructor<User> constructor = null;
 		Object[] parameterValues = new Object[] { null };
 
-		executableValidator.validateConstructorParameters(
+		getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
@@ -382,7 +374,7 @@ public class ValidateConstructorParametersTest extends Arquillian {
 		Constructor<User> constructor = User.class.getConstructor( String.class );
 		Object[] parameterValues = null;
 
-		executableValidator.validateConstructorParameters(
+		getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
@@ -394,7 +386,7 @@ public class ValidateConstructorParametersTest extends Arquillian {
 		Constructor<User> constructor = User.class.getConstructor( String.class );
 		Object[] parameterValues = new Object[] { null };
 
-		executableValidator.validateConstructorParameters(
+		getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues,
 				(Class<?>[]) null
@@ -407,7 +399,7 @@ public class ValidateConstructorParametersTest extends Arquillian {
 		Constructor<User> constructor = User.class.getConstructor( String.class );
 		Object[] parameterValues = new Object[] { null };
 
-		executableValidator.validateConstructorParameters(
+		getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues,
 				(Class<?>) null
@@ -426,7 +418,7 @@ public class ValidateConstructorParametersTest extends Arquillian {
 		Constructor<OrderLine> constructor = OrderLine.class.getConstructor( Item.class );
 		Object[] parameterValues = new Object[] { leaf };
 
-		Set<ConstraintViolation<OrderLine>> violations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<OrderLine>> violations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ValidateConstructorReturnValueTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ValidateConstructorReturnValueTest.java
@@ -12,15 +12,12 @@ import java.util.Set;
 import javax.validation.ConstraintViolation;
 import javax.validation.ElementKind;
 import javax.validation.ValidationException;
-import javax.validation.executable.ExecutableValidator;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.constraint.MyCrossParameterConstraint;
@@ -33,6 +30,7 @@ import org.hibernate.beanvalidation.tck.tests.methodvalidation.model.Customer.Ex
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.model.Email;
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.model.Item;
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.model.OrderLine;
+import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
 import org.hibernate.beanvalidation.tck.util.TestUtil;
 import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
@@ -42,6 +40,7 @@ import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectPathNo
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectPathNodeNames;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.kinds;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.names;
+import static org.hibernate.beanvalidation.tck.util.TestUtil.webArchiveBuilder;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
@@ -49,13 +48,11 @@ import static org.testng.Assert.assertNull;
  * @author Gunnar Morling
  */
 @SpecVersion(spec = "beanvalidation", version = "2.0.0")
-public class ValidateConstructorReturnValueTest extends Arquillian {
-
-	private ExecutableValidator executableValidator;
+public class ValidateConstructorReturnValueTest extends BaseExecutableValidatorTest {
 
 	@Deployment
 	public static WebArchive createTestArchive() {
-		return new WebArchiveBuilder()
+		return webArchiveBuilder()
 				.withTestClass( ValidateConstructorReturnValueTest.class )
 				.withPackage( MyCrossParameterConstraint.class.getPackage() )
 				.withClass( Address.class )
@@ -64,11 +61,6 @@ public class ValidateConstructorReturnValueTest extends Arquillian {
 				.withClass( Item.class )
 				.withClass( OrderLine.class )
 				.build();
-	}
-
-	@BeforeMethod
-	public void setupValidator() {
-		executableValidator = TestUtil.getValidatorUnderTest().forExecutables();
 	}
 
 	@Test
@@ -86,7 +78,7 @@ public class ValidateConstructorReturnValueTest extends Arquillian {
 		Constructor<Customer> constructor = Customer.class.getConstructor();
 		Customer returnValue = new Customer();
 
-		Set<ConstraintViolation<Customer>> violations = executableValidator.validateConstructorReturnValue(
+		Set<ConstraintViolation<Customer>> violations = getExecutableValidator().validateConstructorReturnValue(
 				constructor,
 				returnValue
 		);
@@ -115,7 +107,7 @@ public class ValidateConstructorReturnValueTest extends Arquillian {
 		Constructor<Customer> constructor = Customer.class.getConstructor( String.class );
 		Customer returnValue = new Customer();
 
-		Set<ConstraintViolation<Customer>> violations = executableValidator.validateConstructorReturnValue(
+		Set<ConstraintViolation<Customer>> violations = getExecutableValidator().validateConstructorReturnValue(
 				constructor,
 				returnValue
 		);
@@ -141,7 +133,7 @@ public class ValidateConstructorReturnValueTest extends Arquillian {
 		Constructor<Customer> constructor = Customer.class.getConstructor( CharSequence.class );
 		Customer returnValue = new Customer();
 
-		Set<ConstraintViolation<Customer>> violations = executableValidator.validateConstructorReturnValue(
+		Set<ConstraintViolation<Customer>> violations = getExecutableValidator().validateConstructorReturnValue(
 				constructor,
 				returnValue
 		);
@@ -167,7 +159,7 @@ public class ValidateConstructorReturnValueTest extends Arquillian {
 		Constructor<Customer> constructor = Customer.class.getConstructor();
 		Customer returnValue = new Customer( "Bob" );
 
-		Set<ConstraintViolation<Customer>> violations = executableValidator.validateConstructorReturnValue(
+		Set<ConstraintViolation<Customer>> violations = getExecutableValidator().validateConstructorReturnValue(
 				constructor,
 				returnValue
 		);
@@ -181,14 +173,14 @@ public class ValidateConstructorReturnValueTest extends Arquillian {
 		Constructor<Customer> constructor = Customer.class.getConstructor( long.class );
 		Customer returnValue = new Customer();
 
-		Set<ConstraintViolation<Customer>> violations = executableValidator.validateConstructorReturnValue(
+		Set<ConstraintViolation<Customer>> violations = getExecutableValidator().validateConstructorReturnValue(
 				constructor,
 				returnValue
 		);
 
 		assertCorrectNumberOfViolations( violations, 0 );
 
-		violations = executableValidator.validateConstructorReturnValue(
+		violations = getExecutableValidator().validateConstructorReturnValue(
 				constructor,
 				returnValue,
 				Extended.class
@@ -208,14 +200,14 @@ public class ValidateConstructorReturnValueTest extends Arquillian {
 		Constructor<Customer> constructor = Customer.class.getConstructor( Date.class );
 		Customer returnValue = new Customer();
 
-		Set<ConstraintViolation<Customer>> violations = executableValidator.validateConstructorReturnValue(
+		Set<ConstraintViolation<Customer>> violations = getExecutableValidator().validateConstructorReturnValue(
 				constructor,
 				returnValue
 		);
 
 		assertCorrectNumberOfViolations( violations, 0 );
 
-		violations = executableValidator.validateConstructorReturnValue(
+		violations = getExecutableValidator().validateConstructorReturnValue(
 				constructor,
 				returnValue,
 				Basic.class,
@@ -241,7 +233,7 @@ public class ValidateConstructorReturnValueTest extends Arquillian {
 		Constructor<Email> constructor = Email.class.getConstructor();
 		Email returnValue = new Email();
 
-		executableValidator.validateConstructorReturnValue( constructor, returnValue );
+		getExecutableValidator().validateConstructorReturnValue( constructor, returnValue );
 	}
 
 	@Test(expectedExceptions = IllegalArgumentException.class)
@@ -250,7 +242,7 @@ public class ValidateConstructorReturnValueTest extends Arquillian {
 		Constructor<Customer> constructor = null;
 		Customer returnValue = new Customer();
 
-		executableValidator.validateConstructorReturnValue(
+		getExecutableValidator().validateConstructorReturnValue(
 				constructor,
 				returnValue
 		);
@@ -262,7 +254,7 @@ public class ValidateConstructorReturnValueTest extends Arquillian {
 		Constructor<Customer> constructor = Customer.class.getConstructor();
 		Customer returnValue = null;
 
-		executableValidator.validateConstructorReturnValue(
+		getExecutableValidator().validateConstructorReturnValue(
 				constructor,
 				returnValue
 		);
@@ -274,7 +266,7 @@ public class ValidateConstructorReturnValueTest extends Arquillian {
 		Constructor<Customer> constructor = Customer.class.getConstructor();
 		Customer returnValue = new Customer();
 
-		executableValidator.validateConstructorReturnValue(
+		getExecutableValidator().validateConstructorReturnValue(
 				constructor,
 				returnValue,
 				(Class<?>[]) null
@@ -287,7 +279,7 @@ public class ValidateConstructorReturnValueTest extends Arquillian {
 		Constructor<Customer> constructor = Customer.class.getConstructor();
 		Customer returnValue = new Customer();
 
-		executableValidator.validateConstructorReturnValue(
+		getExecutableValidator().validateConstructorReturnValue(
 				constructor,
 				returnValue,
 				(Class<?>) null
@@ -306,7 +298,7 @@ public class ValidateConstructorReturnValueTest extends Arquillian {
 		Object createdObject = new OrderLine( leaf );
 		Constructor<OrderLine> constructor = OrderLine.class.getConstructor( Item.class );
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateConstructorReturnValue(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateConstructorReturnValue(
 				constructor,
 				createdObject
 		);

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ValidateParametersTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ValidateParametersTest.java
@@ -15,15 +15,12 @@ import javax.validation.ValidationException;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
-import javax.validation.executable.ExecutableValidator;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.constraint.MyCrossParameterConstraint;
@@ -33,6 +30,7 @@ import org.hibernate.beanvalidation.tck.tests.methodvalidation.model.OrderLine;
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.model.User;
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.model.User.Basic;
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.model.User.Extended;
+import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
 import org.hibernate.beanvalidation.tck.util.TestUtil;
 import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
@@ -42,6 +40,7 @@ import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectPathNo
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectPathNodeNames;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.kinds;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.names;
+import static org.hibernate.beanvalidation.tck.util.TestUtil.webArchiveBuilder;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
@@ -49,13 +48,11 @@ import static org.testng.Assert.assertNull;
  * @author Gunnar Morling
  */
 @SpecVersion(spec = "beanvalidation", version = "2.0.0")
-public class ValidateParametersTest extends Arquillian {
-
-	private ExecutableValidator executableValidator;
+public class ValidateParametersTest extends BaseExecutableValidatorTest {
 
 	@Deployment
 	public static WebArchive createTestArchive() {
-		return new WebArchiveBuilder()
+		return webArchiveBuilder()
 				.withTestClass( ValidateParametersTest.class )
 				.withPackage( MyCrossParameterConstraint.class.getPackage() )
 				.withClass( Address.class )
@@ -63,11 +60,6 @@ public class ValidateParametersTest extends Arquillian {
 				.withClass( OrderLine.class )
 				.withClass( User.class )
 				.build();
-	}
-
-	@BeforeMethod
-	public void setupValidator() {
-		executableValidator = TestUtil.getValidatorUnderTest().forExecutables();
 	}
 
 	@Test
@@ -89,7 +81,7 @@ public class ValidateParametersTest extends Arquillian {
 		String arg0 = "B";
 		Object[] parameterValues = new Object[] { arg0 };
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -123,7 +115,7 @@ public class ValidateParametersTest extends Arquillian {
 		Method method = User.class.getMethod( methodName, String.class, String.class );
 		Object[] parameterValues = new Object[] { null, null };
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -149,7 +141,7 @@ public class ValidateParametersTest extends Arquillian {
 		Method method = User.class.getMethod( methodName, String.class, CharSequence.class );
 		Object[] parameterValues = new Object[] { null, "S" };
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -179,7 +171,7 @@ public class ValidateParametersTest extends Arquillian {
 		Method method = User.class.getMethod( methodName, String.class, int.class );
 		Object[] parameterValues = new Object[] { "S", 0 };
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -209,7 +201,7 @@ public class ValidateParametersTest extends Arquillian {
 		Method method = User.class.getMethod( methodName, CharSequence.class );
 		Object[] parameterValues = new Object[] { "S" };
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -244,7 +236,7 @@ public class ValidateParametersTest extends Arquillian {
 		);
 		Object[] parameterValues = new Object[] { null, null, null };
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -276,7 +268,7 @@ public class ValidateParametersTest extends Arquillian {
 		Method method = User.class.getMethod( "setNames", String.class, CharSequence.class );
 		Object[] parameterValues = new Object[] { "Bob", "Smith" };
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -294,7 +286,7 @@ public class ValidateParametersTest extends Arquillian {
 		Method method = User.class.getMethod( methodName, String.class, long.class );
 		Object[] parameterValues = new Object[] { "S", 0l };
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -302,7 +294,7 @@ public class ValidateParametersTest extends Arquillian {
 
 		assertCorrectNumberOfViolations( violations, 0 );
 
-		violations = executableValidator.validateParameters(
+		violations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues,
@@ -323,7 +315,7 @@ public class ValidateParametersTest extends Arquillian {
 		Method method = User.class.getMethod( methodName, CharSequence.class, String.class );
 		Object[] parameterValues = new Object[] { null, null };
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -331,7 +323,7 @@ public class ValidateParametersTest extends Arquillian {
 
 		assertCorrectNumberOfViolations( violations, 0 );
 
-		violations = executableValidator.validateParameters(
+		violations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues,
@@ -352,7 +344,7 @@ public class ValidateParametersTest extends Arquillian {
 		Method method = User.class.getMethod( methodName, String.class, String.class, Date.class );
 		Object[] parameterValues = new Object[] { null, "S", null };
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -360,7 +352,7 @@ public class ValidateParametersTest extends Arquillian {
 
 		assertCorrectNumberOfViolations( violations, 0 );
 
-		violations = executableValidator.validateParameters(
+		violations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues,
@@ -392,7 +384,7 @@ public class ValidateParametersTest extends Arquillian {
 		Method method = Address.class.getMethod( methodName, String.class );
 		Object[] parameterValues = new Object[] { "S" };
 
-		executableValidator.validateParameters( object, method, parameterValues );
+		getExecutableValidator().validateParameters( object, method, parameterValues );
 	}
 
 	@Test(expectedExceptions = IllegalArgumentException.class)
@@ -402,7 +394,7 @@ public class ValidateParametersTest extends Arquillian {
 		Method method = User.class.getMethod( "setFirstName", String.class );
 		Object[] parameterValues = new Object[] { null };
 
-		executableValidator.validateParameters(
+		getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -416,7 +408,7 @@ public class ValidateParametersTest extends Arquillian {
 		Method method = null;
 		Object[] parameterValues = new Object[] { null };
 
-		executableValidator.validateParameters(
+		getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -430,7 +422,7 @@ public class ValidateParametersTest extends Arquillian {
 		Method method = User.class.getMethod( "setFirstName", String.class );
 		Object[] parameterValues = null;
 
-		executableValidator.validateParameters(
+		getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -444,7 +436,7 @@ public class ValidateParametersTest extends Arquillian {
 		Method method = User.class.getMethod( "setFirstName", String.class );
 		Object[] parameterValues = new Object[] { null };
 
-		executableValidator.validateParameters(
+		getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues,
@@ -459,7 +451,7 @@ public class ValidateParametersTest extends Arquillian {
 		Method method = User.class.getMethod( "setFirstName", String.class );
 		Object[] parameterValues = new Object[] { null };
 
-		executableValidator.validateParameters(
+		getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues,
@@ -482,7 +474,7 @@ public class ValidateParametersTest extends Arquillian {
 		Method method = OrderLine.class.getMethod( methodName, Item.class );
 		Object[] parameterValues = new Object[] { leaf };
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ValidateReturnValueTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ValidateReturnValueTest.java
@@ -14,15 +14,12 @@ import javax.validation.ElementKind;
 import javax.validation.ValidationException;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
-import javax.validation.executable.ExecutableValidator;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.constraint.MyCrossParameterConstraint;
@@ -33,6 +30,7 @@ import org.hibernate.beanvalidation.tck.tests.methodvalidation.model.Customer.Ex
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.model.Email;
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.model.Item;
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.model.OrderLine;
+import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
 import org.hibernate.beanvalidation.tck.util.TestUtil;
 import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
@@ -42,6 +40,7 @@ import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectPathNo
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectPathNodeNames;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.kinds;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.names;
+import static org.hibernate.beanvalidation.tck.util.TestUtil.webArchiveBuilder;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
@@ -49,13 +48,11 @@ import static org.testng.Assert.assertNull;
  * @author Gunnar Morling
  */
 @SpecVersion(spec = "beanvalidation", version = "2.0.0")
-public class ValidateReturnValueTest extends Arquillian {
-
-	private ExecutableValidator executableValidator;
+public class ValidateReturnValueTest extends BaseExecutableValidatorTest {
 
 	@Deployment
 	public static WebArchive createTestArchive() {
-		return new WebArchiveBuilder()
+		return webArchiveBuilder()
 				.withTestClass( ValidateReturnValueTest.class )
 				.withPackage( MyCrossParameterConstraint.class.getPackage() )
 				.withClass( Address.class )
@@ -64,11 +61,6 @@ public class ValidateReturnValueTest extends Arquillian {
 				.withClass( Item.class )
 				.withClass( OrderLine.class )
 				.build();
-	}
-
-	@BeforeMethod
-	public void setupValidator() {
-		executableValidator = TestUtil.getValidatorUnderTest().forExecutables();
 	}
 
 	@Test
@@ -89,7 +81,7 @@ public class ValidateReturnValueTest extends Arquillian {
 		Method method = Customer.class.getMethod( methodName );
 		Object returnValue = "B";
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
@@ -119,7 +111,7 @@ public class ValidateReturnValueTest extends Arquillian {
 		Method method = Customer.class.getMethod( methodName, String.class );
 		Object returnValue = "S";
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
@@ -149,7 +141,7 @@ public class ValidateReturnValueTest extends Arquillian {
 		Method method = Customer.class.getMethod( methodName, CharSequence.class );
 		Object returnValue = "S";
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
@@ -177,7 +169,7 @@ public class ValidateReturnValueTest extends Arquillian {
 		Method method = Customer.class.getMethod( "getFirstName", String.class );
 		Object returnValue = "aaa";
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
@@ -195,7 +187,7 @@ public class ValidateReturnValueTest extends Arquillian {
 		Method method = Customer.class.getMethod( methodName, long.class );
 		Object returnValue = "S";
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
@@ -203,7 +195,7 @@ public class ValidateReturnValueTest extends Arquillian {
 
 		assertCorrectNumberOfViolations( violations, 0 );
 
-		violations = executableValidator.validateReturnValue(
+		violations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue,
@@ -224,7 +216,7 @@ public class ValidateReturnValueTest extends Arquillian {
 		Method method = Customer.class.getMethod( methodName, Date.class );
 		Object returnValue = "S";
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
@@ -232,7 +224,7 @@ public class ValidateReturnValueTest extends Arquillian {
 
 		assertCorrectNumberOfViolations( violations, 0 );
 
-		violations = executableValidator.validateReturnValue(
+		violations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue,
@@ -262,7 +254,7 @@ public class ValidateReturnValueTest extends Arquillian {
 		Method method = Email.class.getMethod( methodName );
 		Object returnValue = "S";
 
-		executableValidator.validateReturnValue( object, method, returnValue );
+		getExecutableValidator().validateReturnValue( object, method, returnValue );
 	}
 
 	@Test(expectedExceptions = IllegalArgumentException.class)
@@ -272,7 +264,7 @@ public class ValidateReturnValueTest extends Arquillian {
 		Method method = Customer.class.getMethod( "getAddress" );
 		Object returnValue = null;
 
-		executableValidator.validateReturnValue(
+		getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
@@ -286,7 +278,7 @@ public class ValidateReturnValueTest extends Arquillian {
 		Method method = null;
 		Object returnValue = null;
 
-		executableValidator.validateReturnValue(
+		getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
@@ -300,7 +292,7 @@ public class ValidateReturnValueTest extends Arquillian {
 		Method method = Customer.class.getMethod( "getAddress" );
 		Object returnValue = null;
 
-		executableValidator.validateReturnValue(
+		getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue,
@@ -315,7 +307,7 @@ public class ValidateReturnValueTest extends Arquillian {
 		Method method = Customer.class.getMethod( "getAddress" );
 		Object returnValue = null;
 
-		executableValidator.validateReturnValue(
+		getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue,
@@ -337,7 +329,7 @@ public class ValidateReturnValueTest extends Arquillian {
 		Item returnValue = new Item( "foo" );
 		Method method = OrderLine.class.getMethod( methodName );
 
-		Set<ConstraintViolation<Object>> violations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> violations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/parameternameprovider/DefaultParameterNameProviderTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/parameternameprovider/DefaultParameterNameProviderTest.java
@@ -13,22 +13,21 @@ import java.util.Date;
 import java.util.Set;
 import javax.validation.ConstraintViolation;
 import javax.validation.ParameterNameProvider;
-import javax.validation.Validator;
+
+import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
+import org.hibernate.beanvalidation.tck.util.TestUtil;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
 
-import org.hibernate.beanvalidation.tck.util.TestUtil;
-import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
+import org.testng.annotations.Test;
 
 import static org.hibernate.beanvalidation.tck.util.TestUtil.asSet;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectNumberOfViolations;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.getParameterNames;
+import static org.hibernate.beanvalidation.tck.util.TestUtil.webArchiveBuilder;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
@@ -36,22 +35,16 @@ import static org.testng.Assert.assertNotNull;
  * @author Gunnar Morling
  */
 @SpecVersion(spec = "beanvalidation", version = "2.0.0")
-public class DefaultParameterNameProviderTest extends Arquillian {
-
-	private Validator validator;
+public class DefaultParameterNameProviderTest extends BaseExecutableValidatorTest {
 
 	@Deployment
 	public static WebArchive createTestArchive() {
-		return new WebArchiveBuilder()
+		return webArchiveBuilder()
 				.withTestClass( DefaultParameterNameProviderTest.class )
-				.withClass( BrokenCustomParameterNameProvider.class )
-				.withClass( User.class )
-				.build();
-	}
-
-	@BeforeMethod
-	public void setupValidator() {
-		validator = TestUtil.getValidatorUnderTest();
+				.withClasses(
+						BrokenCustomParameterNameProvider.class,
+						User.class
+				).build();
 	}
 
 	@Test
@@ -61,7 +54,7 @@ public class DefaultParameterNameProviderTest extends Arquillian {
 		Method method = User.class.getMethod( "setNames", String.class, String.class );
 		Object[] parameters = new Object[] { null, null };
 
-		Set<ConstraintViolation<Object>> constraintViolations = validator.forExecutables()
+		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator()
 				.validateParameters( object, method, parameters );
 		assertCorrectNumberOfViolations( constraintViolations, 2 );
 
@@ -81,7 +74,7 @@ public class DefaultParameterNameProviderTest extends Arquillian {
 		);
 		Object[] parameters = new Object[] { null, null, null };
 
-		Set<ConstraintViolation<User>> constraintViolations = validator.forExecutables()
+		Set<ConstraintViolation<User>> constraintViolations = getExecutableValidator()
 				.validateConstructorParameters( constructor, parameters );
 		assertCorrectNumberOfViolations( constraintViolations, 3 );
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/GetterDefinitionTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/GetterDefinitionTest.java
@@ -8,42 +8,33 @@ package org.hibernate.beanvalidation.tck.tests.validation;
 
 import java.util.Set;
 import javax.validation.ConstraintViolation;
-import javax.validation.Validator;
 import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.NotNull;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import org.hibernate.beanvalidation.tck.util.TestUtil;
+import org.hibernate.beanvalidation.tck.tests.BaseValidatorTest;
 import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectConstraintTypes;
+import static org.hibernate.beanvalidation.tck.util.TestUtil.webArchiveBuilder;
 
 /**
  * @author Gunnar Morling
  */
 @SpecVersion(spec = "beanvalidation", version = "2.0.0")
-public class GetterDefinitionTest extends Arquillian {
-
-	private Validator validator;
+public class GetterDefinitionTest extends BaseValidatorTest {
 
 	@Deployment
 	public static WebArchive createTestArchive() {
-		return new WebArchiveBuilder()
+		return webArchiveBuilder()
 				.withTestClass( GetterDefinitionTest.class )
 				.withClasses( Shipment.class )
 				.build();
-	}
-
-	@BeforeMethod
-	public void setupValidator() {
-		validator = TestUtil.getValidatorUnderTest();
 	}
 
 	@Test
@@ -51,7 +42,7 @@ public class GetterDefinitionTest extends Arquillian {
 	public void testGetterMethod() {
 		Shipment shipment = new Shipment();
 
-		Set<ConstraintViolation<Shipment>> constraintViolations = validator.validateProperty( shipment, "id" );
+		Set<ConstraintViolation<Shipment>> constraintViolations = getValidator().validateProperty( shipment, "id" );
 		assertCorrectConstraintTypes( constraintViolations, NotNull.class );
 	}
 
@@ -60,7 +51,7 @@ public class GetterDefinitionTest extends Arquillian {
 	public void testBooleanGetterMethod() {
 		Shipment shipment = new Shipment();
 
-		Set<ConstraintViolation<Shipment>> constraintViolations = validator.validateProperty( shipment, "shipped" );
+		Set<ConstraintViolation<Shipment>> constraintViolations = getValidator().validateProperty( shipment, "shipped" );
 		assertCorrectConstraintTypes( constraintViolations, AssertTrue.class );
 	}
 }

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/PropertyPathTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/PropertyPathTest.java
@@ -32,18 +32,16 @@ import javax.validation.Path.PropertyNode;
 import javax.validation.Path.ReturnValueNode;
 import javax.validation.Payload;
 import javax.validation.Valid;
-import javax.validation.Validator;
 import javax.validation.executable.ExecutableValidator;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
 import org.hibernate.beanvalidation.tck.util.TestUtil;
 import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
@@ -52,6 +50,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.asSet;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectNumberOfViolations;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.getConstraintViolationForParameter;
+import static org.hibernate.beanvalidation.tck.util.TestUtil.webArchiveBuilder;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -63,15 +62,11 @@ import static org.testng.Assert.assertTrue;
  * @author Hardy Ferentschik
  */
 @SpecVersion(spec = "beanvalidation", version = "2.0.0")
-public class PropertyPathTest extends Arquillian {
-
-	private Validator validator;
-
-	private ExecutableValidator executableValidator;
+public class PropertyPathTest extends BaseExecutableValidatorTest {
 
 	@Deployment
 	public static WebArchive createTestArchive() {
-		return new WebArchiveBuilder()
+		return webArchiveBuilder()
 				.withTestClass( PropertyPathTest.class )
 				.withClasses(
 						Actor.class,
@@ -96,12 +91,6 @@ public class PropertyPathTest extends Arquillian {
 				.build();
 	}
 
-	@BeforeMethod
-	public void setupValidators() {
-		validator = TestUtil.getValidatorUnderTest();
-		executableValidator = validator.forExecutables();
-	}
-
 	@Test
 	@SpecAssertions({
 			@SpecAssertion(section = "5.2", id = "l"),
@@ -115,7 +104,7 @@ public class PropertyPathTest extends Arquillian {
 			@SpecAssertion(section = "5.2", id = "ab")
 	})
 	public void testPropertyPathWithConstraintViolationForRootObject() {
-		Set<ConstraintViolation<VerySpecialClass>> constraintViolations = validator.validate( new VerySpecialClass() );
+		Set<ConstraintViolation<VerySpecialClass>> constraintViolations = getValidator().validate( new VerySpecialClass() );
 		assertCorrectNumberOfViolations( constraintViolations, 1 );
 		ConstraintViolation<VerySpecialClass> constraintViolation = constraintViolations.iterator()
 				.next();
@@ -146,7 +135,7 @@ public class PropertyPathTest extends Arquillian {
 	public void testPropertyPathTraversedObject() {
 		Engine engine = new Engine();
 		engine.setSerialNumber( "ABCDEFGH1234" );
-		Set<ConstraintViolation<Engine>> constraintViolations = validator.validate( engine );
+		Set<ConstraintViolation<Engine>> constraintViolations = getValidator().validate( engine );
 		assertCorrectNumberOfViolations( constraintViolations, 1 );
 
 		ConstraintViolation<Engine> constraintViolation = constraintViolations.iterator().next();
@@ -182,7 +171,7 @@ public class PropertyPathTest extends Arquillian {
 		charlie.addPlayedWith( morgan );
 		morgan.addPlayedWith( charlie );
 
-		Set<ConstraintViolation<Actor>> constraintViolations = validator.validate( clint );
+		Set<ConstraintViolation<Actor>> constraintViolations = getValidator().validate( clint );
 		checkActorViolations( constraintViolations );
 	}
 
@@ -207,7 +196,7 @@ public class PropertyPathTest extends Arquillian {
 		charlie.addPlayedWith( morgan );
 		morgan.addPlayedWith( charlie );
 
-		Set<ConstraintViolation<Actor>> constraintViolations = validator.validate( clint );
+		Set<ConstraintViolation<Actor>> constraintViolations = getValidator().validate( clint );
 		checkActorViolations( constraintViolations );
 	}
 
@@ -233,7 +222,7 @@ public class PropertyPathTest extends Arquillian {
 		charlie.addPlayedWith( morgan );
 		morgan.addPlayedWith( charlie );
 
-		Set<ConstraintViolation<Actor>> constraintViolations = validator.validate( clint );
+		Set<ConstraintViolation<Actor>> constraintViolations = getValidator().validate( clint );
 		checkActorViolations( constraintViolations );
 	}
 
@@ -253,7 +242,7 @@ public class PropertyPathTest extends Arquillian {
 		Actor morgan = new ActorArrayBased( "Morgan", null );
 		Integer id = db.addActor( morgan );
 
-		Set<ConstraintViolation<ActorDB>> constraintViolations = validator.validate( db );
+		Set<ConstraintViolation<ActorDB>> constraintViolations = getValidator().validate( db );
 		assertCorrectNumberOfViolations( constraintViolations, 1 );
 
 		ConstraintViolation<ActorDB> constraintViolation = constraintViolations.iterator().next();
@@ -286,7 +275,7 @@ public class PropertyPathTest extends Arquillian {
 		Order order = new Order();
 		customer.addOrder( order );
 
-		Set<ConstraintViolation<Customer>> constraintViolations = validator.validate( customer );
+		Set<ConstraintViolation<Customer>> constraintViolations = getValidator().validate( customer );
 		assertCorrectNumberOfViolations( constraintViolations, 1 );
 
 		ConstraintViolation<Customer> constraintViolation = constraintViolations.iterator().next();
@@ -330,7 +319,7 @@ public class PropertyPathTest extends Arquillian {
 		Object[] parameterValues = new Object[] { null, null, null };
 
 		//when
-		Set<ConstraintViolation<Object>> constraintViolations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -472,7 +461,7 @@ public class PropertyPathTest extends Arquillian {
 		Object returnValue = null;
 
 		//when
-		Set<ConstraintViolation<Object>> constraintViolations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
@@ -520,7 +509,7 @@ public class PropertyPathTest extends Arquillian {
 		Object[] parameterValues = new Object[] { null, null };
 
 		//when
-		Set<ConstraintViolation<Object>> constraintViolations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -571,7 +560,7 @@ public class PropertyPathTest extends Arquillian {
 		Object[] parameterValues = new Object[] { null, null };
 
 		//when
-		Set<ConstraintViolation<MovieStudio>> constraintViolations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<MovieStudio>> constraintViolations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
@@ -698,7 +687,7 @@ public class PropertyPathTest extends Arquillian {
 		Object[] parameterValues = new Object[] { null, null };
 
 		//when
-		Set<ConstraintViolation<MovieStudio>> constraintViolations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<MovieStudio>> constraintViolations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
@@ -748,7 +737,7 @@ public class PropertyPathTest extends Arquillian {
 		MovieStudio returnValue = new MovieStudio( null );
 
 		//when
-		Set<ConstraintViolation<MovieStudio>> constraintViolations = executableValidator.validateConstructorReturnValue(
+		Set<ConstraintViolation<MovieStudio>> constraintViolations = getExecutableValidator().validateConstructorReturnValue(
 				constructor,
 				returnValue
 		);
@@ -795,7 +784,7 @@ public class PropertyPathTest extends Arquillian {
 		};
 
 		//when
-		Set<ConstraintViolation<Object>> constraintViolations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -855,7 +844,7 @@ public class PropertyPathTest extends Arquillian {
 		};
 
 		//when
-		Set<ConstraintViolation<Object>> constraintViolations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -915,7 +904,7 @@ public class PropertyPathTest extends Arquillian {
 		};
 
 		//when
-		Set<ConstraintViolation<Object>> constraintViolations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -971,7 +960,7 @@ public class PropertyPathTest extends Arquillian {
 		};
 
 		//when
-		Set<ConstraintViolation<Object>> constraintViolations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -1031,7 +1020,7 @@ public class PropertyPathTest extends Arquillian {
 		};
 
 		//when
-		Set<ConstraintViolation<Object>> constraintViolations = executableValidator.validateParameters(
+		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator().validateParameters(
 				object,
 				method,
 				parameterValues
@@ -1078,7 +1067,7 @@ public class PropertyPathTest extends Arquillian {
 		Object[] parameterValues = new Object[] { validStudioName(), employWithoutFirstName() };
 
 		//when
-		Set<ConstraintViolation<MovieStudio>> constraintViolations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<MovieStudio>> constraintViolations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
@@ -1134,7 +1123,7 @@ public class PropertyPathTest extends Arquillian {
 		};
 
 		//when
-		Set<ConstraintViolation<MovieStudio>> constraintViolations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<MovieStudio>> constraintViolations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
@@ -1190,7 +1179,7 @@ public class PropertyPathTest extends Arquillian {
 		};
 
 		//when
-		Set<ConstraintViolation<MovieStudio>> constraintViolations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<MovieStudio>> constraintViolations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
@@ -1242,7 +1231,7 @@ public class PropertyPathTest extends Arquillian {
 		};
 
 		//when
-		Set<ConstraintViolation<MovieStudio>> constraintViolations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<MovieStudio>> constraintViolations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
@@ -1298,7 +1287,7 @@ public class PropertyPathTest extends Arquillian {
 		};
 
 		//when
-		Set<ConstraintViolation<MovieStudio>> constraintViolations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<MovieStudio>> constraintViolations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
@@ -1343,7 +1332,7 @@ public class PropertyPathTest extends Arquillian {
 		Object returnValue = new Movie();
 
 		//when
-		Set<ConstraintViolation<Object>> constraintViolations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
@@ -1394,7 +1383,7 @@ public class PropertyPathTest extends Arquillian {
 		);
 
 		//when
-		Set<ConstraintViolation<Object>> constraintViolations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
@@ -1445,7 +1434,7 @@ public class PropertyPathTest extends Arquillian {
 		};
 
 		//when
-		Set<ConstraintViolation<Object>> constraintViolations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
@@ -1492,7 +1481,7 @@ public class PropertyPathTest extends Arquillian {
 		Object returnValue = asSet( new Movie( validFilmTitle() ), new Movie() );
 
 		//when
-		Set<ConstraintViolation<Object>> constraintViolations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
@@ -1543,7 +1532,7 @@ public class PropertyPathTest extends Arquillian {
 		returnValue.put( "NO_TITLE", new Movie() );
 
 		//when
-		Set<ConstraintViolation<Object>> constraintViolations = executableValidator.validateReturnValue(
+		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator().validateReturnValue(
 				object,
 				method,
 				returnValue
@@ -1587,7 +1576,7 @@ public class PropertyPathTest extends Arquillian {
 		MovieStudio returnValue = new MovieStudio( null );
 
 		//when
-		Set<ConstraintViolation<MovieStudio>> constraintViolations = executableValidator.validateConstructorReturnValue(
+		Set<ConstraintViolation<MovieStudio>> constraintViolations = getExecutableValidator().validateConstructorReturnValue(
 				constructor,
 				returnValue
 		);
@@ -1615,7 +1604,7 @@ public class PropertyPathTest extends Arquillian {
 	@Test(expectedExceptions = ClassCastException.class)
 	@SpecAssertion(section = "5.2", id = "r")
 	public void testPassingWrongTypeToAsOnBeanNodeCausesClassCastException() {
-		Set<ConstraintViolation<VerySpecialClass>> constraintViolations = validator.validate( new VerySpecialClass() );
+		Set<ConstraintViolation<VerySpecialClass>> constraintViolations = getValidator().validate( new VerySpecialClass() );
 		assertCorrectNumberOfViolations( constraintViolations, 1 );
 		ConstraintViolation<VerySpecialClass> constraintViolation = constraintViolations.iterator().next();
 
@@ -1639,7 +1628,7 @@ public class PropertyPathTest extends Arquillian {
 		Object[] parameterValues = new Object[] { null, null };
 
 		//when
-		Set<ConstraintViolation<MovieStudio>> constraintViolations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<MovieStudio>> constraintViolations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);
@@ -1671,7 +1660,7 @@ public class PropertyPathTest extends Arquillian {
 		Object[] parameterValues = new Object[] { null, null };
 
 		//when
-		Set<ConstraintViolation<MovieStudio>> constraintViolations = executableValidator.validateConstructorParameters(
+		Set<ConstraintViolation<MovieStudio>> constraintViolations = getExecutableValidator().validateConstructorParameters(
 				constructor,
 				parameterValues
 		);

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/ValidatePropertyTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/ValidatePropertyTest.java
@@ -9,25 +9,23 @@ package org.hibernate.beanvalidation.tck.tests.validation;
 import java.util.Set;
 import javax.validation.ConstraintViolation;
 import javax.validation.ValidationException;
-import javax.validation.Validator;
 import javax.validation.constraints.Size;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import org.hibernate.beanvalidation.tck.util.TestUtil;
+import org.hibernate.beanvalidation.tck.tests.BaseValidatorTest;
 import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertConstraintViolation;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectConstraintTypes;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectConstraintViolationMessages;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.TestUtil.webArchiveBuilder;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.fail;
@@ -38,34 +36,28 @@ import static org.testng.Assert.fail;
  * @author Hardy Ferentschik
  */
 @SpecVersion(spec = "beanvalidation", version = "2.0.0")
-public class ValidatePropertyTest extends Arquillian {
+public class ValidatePropertyTest extends BaseValidatorTest {
 
-	private Validator validator;
 
 	@Deployment
 	public static WebArchive createTestArchive() {
-		return new WebArchiveBuilder()
+		return webArchiveBuilder()
 				.withTestClass( ValidatePropertyTest.class )
 				.withClasses( Customer.class, Person.class, Order.class, Address.class, BadlyBehavedEntity.class )
 				.build();
-	}
-
-	@BeforeMethod
-	public void setupValidator() {
-		validator = TestUtil.getValidatorUnderTest();
 	}
 
 	@Test(expectedExceptions = IllegalArgumentException.class)
 	@SpecAssertion(section = "5.1.1", id = "e")
 	public void testPassingNullAsGroup() {
 		Customer customer = new Customer();
-		validator.validateProperty( customer, "firstName", (Class<?>) null );
+		getValidator().validateProperty( customer, "firstName", (Class<?>) null );
 	}
 
 	@Test(expectedExceptions = IllegalArgumentException.class)
 	@SpecAssertion(section = "5.1.1", id = "e")
 	public void testIllegalArgumentExceptionIsThrownForNullValue() {
-		validator.validateProperty( null, "firstName" );
+		getValidator().validateProperty( null, "firstName" );
 	}
 
 	@Test
@@ -76,7 +68,7 @@ public class ValidatePropertyTest extends Arquillian {
 	public void testValidatePropertyWithInvalidPropertyPath() {
 		Customer customer = new Customer();
 		try {
-			validator.validateProperty( customer, "foobar" );
+			getValidator().validateProperty( customer, "foobar" );
 			fail();
 		}
 		catch ( IllegalArgumentException e ) {
@@ -86,7 +78,7 @@ public class ValidatePropertyTest extends Arquillian {
 
 		// firstname exists, but the capitalisation is wrong
 		try {
-			validator.validateProperty( customer, "FirstName" );
+			getValidator().validateProperty( customer, "FirstName" );
 			fail();
 		}
 		catch ( IllegalArgumentException e ) {
@@ -98,7 +90,7 @@ public class ValidatePropertyTest extends Arquillian {
 	@SpecAssertion(section = "5.1.1", id = "e")
 	public void testValidatePropertyWithNullProperty() {
 		Customer customer = new Customer();
-		validator.validateProperty( customer, null );
+		getValidator().validateProperty( customer, null );
 	}
 
 	@Test(expectedExceptions = IllegalArgumentException.class)
@@ -108,7 +100,7 @@ public class ValidatePropertyTest extends Arquillian {
 		Order order = new Order();
 		customer.addOrder( order );
 
-		validator.validateProperty( customer, "" );
+		getValidator().validateProperty( customer, "" );
 	}
 
 	@Test
@@ -129,7 +121,7 @@ public class ValidatePropertyTest extends Arquillian {
 		String townInNorthWales = "Llanfairpwllgwyngyllgogerychwyrndrobwyll-llantysiliogogogoch";
 		address.setCity( townInNorthWales );
 
-		Set<ConstraintViolation<Address>> constraintViolations = validator.validateProperty( address, "city" );
+		Set<ConstraintViolation<Address>> constraintViolations = getValidator().validateProperty( address, "city" );
 		assertCorrectNumberOfViolations( constraintViolations, 1 );
 		assertCorrectConstraintTypes( constraintViolations, Size.class );
 
@@ -145,7 +137,7 @@ public class ValidatePropertyTest extends Arquillian {
 		);
 
 		address.setCity( "London" );
-		constraintViolations = validator.validateProperty( address, "city" );
+		constraintViolations = getValidator().validateProperty( address, "city" );
 		assertCorrectNumberOfViolations( constraintViolations, 0 );
 	}
 
@@ -156,13 +148,13 @@ public class ValidatePropertyTest extends Arquillian {
 		Order order = new Order();
 		customer.addOrder( order );
 
-		Set<ConstraintViolation<Customer>> constraintViolations = validator.validateProperty( customer, "orders" );
+		Set<ConstraintViolation<Customer>> constraintViolations = getValidator().validateProperty( customer, "orders" );
 		assertCorrectNumberOfViolations( constraintViolations, 0 );
 	}
 
 	@Test(expectedExceptions = ValidationException.class)
 	@SpecAssertion(section = "5.1.1", id = "k")
 	public void testUnexpectedExceptionsInValidatePropertyGetWrappedInValidationExceptions() {
-		validator.validateProperty( new BadlyBehavedEntity(), "value" );
+		getValidator().validateProperty( new BadlyBehavedEntity(), "value" );
 	}
 }

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/ValueAccessStrategyTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/ValueAccessStrategyTest.java
@@ -13,18 +13,15 @@ import javax.validation.Constraint;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 import javax.validation.Payload;
-import javax.validation.Validator;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import org.hibernate.beanvalidation.tck.util.TestUtil;
+import org.hibernate.beanvalidation.tck.tests.BaseValidatorTest;
 import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
 import static java.lang.annotation.ElementType.CONSTRUCTOR;
@@ -32,28 +29,27 @@ import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.hibernate.beanvalidation.tck.util.TestUtil.webArchiveBuilder;
 import static org.testng.Assert.assertEquals;
 
 /**
  * @author Gunnar Morling
  */
 @SpecVersion(spec = "beanvalidation", version = "2.0.0")
-public class ValueAccessStrategyTest extends Arquillian {
+public class ValueAccessStrategyTest extends BaseValidatorTest {
 
 	@Deployment
 	public static WebArchive createTestArchive() {
-		return new WebArchiveBuilder()
+		return webArchiveBuilder()
 				.withTestClass( ValueAccessStrategyTest.class )
 				.build();
 	}
-
-	private Validator validator;
 
 	@Test
 	@SpecAssertion(section = "4.2", id = "a")
 	public void testValidatedObjectIsPassedToValidatorOfClassLevelConstraint() {
 		Person person = new Person();
-		validator.validate( person );
+		getValidator().validate( person );
 
 		assertEquals( ValidPerson.ValidPersonValidator.validatedValue, person );
 	}
@@ -65,7 +61,7 @@ public class ValueAccessStrategyTest extends Arquillian {
 	})
 	public void testValueFromFieldIsPassedToValidatorOfFieldLevelConstraint() {
 		Person person = new Person();
-		validator.validate( person );
+		getValidator().validate( person );
 
 		assertEquals(
 				ValidFirstName.ValidFirstNameValidator.validatedValue,
@@ -81,14 +77,9 @@ public class ValueAccessStrategyTest extends Arquillian {
 	})
 	public void testValueFromGetterIsPassedToValidatorOfPropertyLevelConstraint() {
 		Person person = new Person();
-		validator.validate( person );
+		getValidator().validate( person );
 
 		assertEquals( ValidName.Validator.validatedValue, "Billy", "Expected value to be retrieved from getter." );
-	}
-
-	@BeforeMethod
-	public void setupValidator() {
-		validator = TestUtil.getValidatorUnderTest();
 	}
 
 	@ValidPerson

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/groupconversion/GroupConversionValidationTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/groupconversion/GroupConversionValidationTest.java
@@ -14,19 +14,17 @@ import javax.validation.ConstraintViolation;
 import javax.validation.ElementKind;
 import javax.validation.Path;
 import javax.validation.Valid;
-import javax.validation.Validator;
 import javax.validation.constraints.NotNull;
 import javax.validation.groups.Default;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
 import org.hibernate.beanvalidation.tck.util.TestUtil;
 import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
@@ -34,26 +32,20 @@ import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectNumber
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectPropertyPaths;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertDescriptorKinds;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertNodeNames;
+import static org.hibernate.beanvalidation.tck.util.TestUtil.webArchiveBuilder;
 import static org.testng.Assert.assertTrue;
 
 /**
  * @author Gunnar Morling
  */
 @SpecVersion(spec = "beanvalidation", version = "2.0.0")
-public class GroupConversionValidationTest extends Arquillian {
-
-	private Validator validator;
+public class GroupConversionValidationTest extends BaseExecutableValidatorTest {
 
 	@Deployment
 	public static WebArchive createTestArchive() {
-		return new WebArchiveBuilder()
+		return webArchiveBuilder()
 				.withTestClassPackage( GroupConversionValidationTest.class )
 				.build();
-	}
-
-	@BeforeMethod
-	public void setupValidator() {
-		validator = TestUtil.getValidatorUnderTest();
 	}
 
 	@Test
@@ -62,7 +54,7 @@ public class GroupConversionValidationTest extends Arquillian {
 			@SpecAssertion(section = "4.6", id = "a")
 	})
 	public void testGroupConversionIsAppliedOnField() {
-		Set<ConstraintViolation<User>> constraintViolations = validator.validate( TestUsers.withInvalidMainAddress() );
+		Set<ConstraintViolation<User>> constraintViolations = getValidator().validate( TestUsers.withInvalidMainAddress() );
 
 		assertCorrectPropertyPaths(
 				constraintViolations,
@@ -79,7 +71,7 @@ public class GroupConversionValidationTest extends Arquillian {
 	public void testSeveralGroupConversionsAppliedOnField() {
 		User userWithInvalidPreferredShipmentAddress = TestUsers.withInvalidPreferredShipmentAddress();
 
-		Set<ConstraintViolation<User>> constraintViolations = validator.validate(
+		Set<ConstraintViolation<User>> constraintViolations = getValidator().validate(
 				userWithInvalidPreferredShipmentAddress
 		);
 
@@ -89,7 +81,7 @@ public class GroupConversionValidationTest extends Arquillian {
 				"preferredShipmentAddress.zipCode"
 		);
 
-		constraintViolations = validator.validate(
+		constraintViolations = getValidator().validate(
 				userWithInvalidPreferredShipmentAddress,
 				Complex.class
 		);
@@ -99,7 +91,7 @@ public class GroupConversionValidationTest extends Arquillian {
 				"preferredShipmentAddress.doorCode"
 		);
 
-		constraintViolations = validator.validate(
+		constraintViolations = getValidator().validate(
 				userWithInvalidPreferredShipmentAddress,
 				Default.class,
 				Complex.class
@@ -112,7 +104,7 @@ public class GroupConversionValidationTest extends Arquillian {
 				"preferredShipmentAddress.doorCode"
 		);
 
-		constraintViolations = validator.validate(
+		constraintViolations = getValidator().validate(
 				userWithInvalidPreferredShipmentAddress,
 				Complete.class
 		);
@@ -128,7 +120,7 @@ public class GroupConversionValidationTest extends Arquillian {
 	@Test
 	@SpecAssertion(section = "4.4.5", id = "c")
 	public void testGroupConversionIsAppliedOnProperty() {
-		Set<ConstraintViolation<User>> constraintViolations = validator.validate( TestUsers.withInvalidShipmentAddress() );
+		Set<ConstraintViolation<User>> constraintViolations = getValidator().validate( TestUsers.withInvalidShipmentAddress() );
 
 		assertCorrectPropertyPaths(
 				constraintViolations,
@@ -146,7 +138,7 @@ public class GroupConversionValidationTest extends Arquillian {
 		Object returnValue = TestAddresses.withInvalidStreet1();
 
 		//when
-		Set<ConstraintViolation<User>> constraintViolations = validator.forExecutables()
+		Set<ConstraintViolation<User>> constraintViolations = getExecutableValidator()
 				.validateReturnValue( user, method, returnValue );
 
 		//then
@@ -168,7 +160,7 @@ public class GroupConversionValidationTest extends Arquillian {
 		Object returnValue = TestAddresses.withInvalidStreet1();
 
 		//when
-		Set<ConstraintViolation<EndUserImpl>> constraintViolations = validator.forExecutables()
+		Set<ConstraintViolation<EndUserImpl>> constraintViolations = getExecutableValidator()
 				.validateReturnValue( user, method, returnValue );
 
 		//then
@@ -190,7 +182,7 @@ public class GroupConversionValidationTest extends Arquillian {
 		Object returnValue = TestAddresses.withInvalidStreet1();
 
 		//when
-		Set<ConstraintViolation<EndUserImpl>> constraintViolations = validator.forExecutables()
+		Set<ConstraintViolation<EndUserImpl>> constraintViolations = getExecutableValidator()
 				.validateReturnValue( user, method, returnValue );
 
 		//then
@@ -211,7 +203,7 @@ public class GroupConversionValidationTest extends Arquillian {
 		Object[] arguments = new Object[] { TestAddresses.withInvalidStreet1() };
 
 		//when
-		Set<ConstraintViolation<User>> constraintViolations = validator.forExecutables()
+		Set<ConstraintViolation<User>> constraintViolations = getExecutableValidator()
 				.validateParameters( user, method, arguments );
 
 		//then
@@ -231,7 +223,7 @@ public class GroupConversionValidationTest extends Arquillian {
 		User createdObject = new User( TestAddresses.withInvalidStreet1() );
 
 		//when
-		Set<ConstraintViolation<User>> constraintViolations = validator.forExecutables()
+		Set<ConstraintViolation<User>> constraintViolations = getExecutableValidator()
 				.validateConstructorReturnValue( constructor, createdObject );
 
 		//then
@@ -257,7 +249,7 @@ public class GroupConversionValidationTest extends Arquillian {
 		Object[] arguments = new Object[] { TestAddresses.withInvalidStreet1() };
 
 		//when
-		Set<ConstraintViolation<User>> constraintViolations = validator.forExecutables()
+		Set<ConstraintViolation<User>> constraintViolations = getExecutableValidator()
 				.validateConstructorParameters( constructor, arguments );
 
 		//then
@@ -272,7 +264,7 @@ public class GroupConversionValidationTest extends Arquillian {
 	@Test
 	@SpecAssertion(section = "4.4.5", id = "d")
 	public void testGroupConversionIsNotExecutedRecursively() {
-		Set<ConstraintViolation<User>> constraintViolations = validator.validate( TestUsers.withInvalidOfficeAddress() );
+		Set<ConstraintViolation<User>> constraintViolations = getValidator().validate( TestUsers.withInvalidOfficeAddress() );
 
 		assertCorrectPropertyPaths(
 				constraintViolations,
@@ -280,7 +272,7 @@ public class GroupConversionValidationTest extends Arquillian {
 				"officeAddress.zipCode"
 		);
 
-		constraintViolations = validator.validate(
+		constraintViolations = getValidator().validate(
 				TestUsers.withInvalidOfficeAddress(),
 				BasicPostal.class
 		);
@@ -296,25 +288,25 @@ public class GroupConversionValidationTest extends Arquillian {
 	public void testGroupConversionWithSequenceAsTo() {
 		User user = TestUsers.validUser();
 
-		Set<ConstraintViolation<User>> constraintViolations = validator.validate( user );
+		Set<ConstraintViolation<User>> constraintViolations = getValidator().validate( user );
 		assertCorrectNumberOfViolations( constraintViolations, 0 );
 
 		user.getWeekendAddress().setDoorCode( "ABC" );
-		constraintViolations = validator.validate( user );
+		constraintViolations = getValidator().validate( user );
 		assertCorrectPropertyPaths( constraintViolations, "weekendAddress.doorCode" );
 
 		user.getWeekendAddress().setStreet1( null );
-		constraintViolations = validator.validate( user );
+		constraintViolations = getValidator().validate( user );
 		assertCorrectPropertyPaths( constraintViolations, "weekendAddress.street1" );
 	}
 
 	@Test
 	@SpecAssertion(section = "4.4.5", id = "b")
 	public void testGroupIsPassedAsIsToNestedElementWithoutConversion() {
-		Set<ConstraintViolation<FooHolder>> constraintViolations = validator.validate( new FooHolder() );
+		Set<ConstraintViolation<FooHolder>> constraintViolations = getValidator().validate( new FooHolder() );
 		assertTrue( constraintViolations.isEmpty(), "No violations expected for default group" );
 
-		constraintViolations = validator.validate( new FooHolder(), Complex.class );
+		constraintViolations = getValidator().validate( new FooHolder(), Complex.class );
 		assertCorrectPropertyPaths( constraintViolations, "foo.bar" );
 	}
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/XmlConfigurationTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/XmlConfigurationTest.java
@@ -17,19 +17,19 @@ import javax.validation.metadata.BeanDescriptor;
 import javax.validation.metadata.ConstraintDescriptor;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import org.hibernate.beanvalidation.tck.tests.BaseValidatorTest;
 import org.hibernate.beanvalidation.tck.util.TestUtil;
 import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectConstraintViolationMessages;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.TestUtil.webArchiveBuilder;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -38,13 +38,11 @@ import static org.testng.Assert.assertTrue;
  * @author Hardy Ferentschik
  */
 @SpecVersion(spec = "beanvalidation", version = "2.0.0")
-public class XmlConfigurationTest extends Arquillian {
-
-	private Validator validator;
+public class XmlConfigurationTest extends BaseValidatorTest {
 
 	@Deployment
 	public static WebArchive createTestArchive() {
-		return new WebArchiveBuilder()
+		return webArchiveBuilder()
 				.withTestClass( XmlConfigurationTest.class )
 				.withClasses(
 						User.class,
@@ -68,11 +66,6 @@ public class XmlConfigurationTest extends Arquillian {
 				.build();
 	}
 
-	@BeforeMethod
-	public void setupValidator() {
-		validator = TestUtil.getValidatorUnderTest();
-	}
-
 	@Test
 	@SpecAssertions({
 			@SpecAssertion(section = "5.5.6", id = "a"),
@@ -84,7 +77,7 @@ public class XmlConfigurationTest extends Arquillian {
 	})
 	public void testClassConstraintDefinedInXml() {
 		User user = new User();
-		Set<ConstraintViolation<User>> constraintViolations = validator.validate( user, TestGroup.class );
+		Set<ConstraintViolation<User>> constraintViolations = getValidator().validate( user, TestGroup.class );
 		assertCorrectNumberOfViolations( constraintViolations, 1 );
 		assertCorrectConstraintViolationMessages(
 				constraintViolations, "Message from xml"
@@ -96,7 +89,7 @@ public class XmlConfigurationTest extends Arquillian {
 		assertTrue( Error.class.equals( payloads.iterator().next() ) );
 
 		user.setConsistent( true );
-		constraintViolations = validator.validate( user );
+		constraintViolations = getValidator().validate( user );
 		assertCorrectNumberOfViolations( constraintViolations, 0 );
 	}
 
@@ -114,7 +107,7 @@ public class XmlConfigurationTest extends Arquillian {
 		Validator validator = config.ignoreXmlConfiguration().buildValidatorFactory().getValidator();
 
 		Order order = new Order();
-		Set<ConstraintViolation<Order>> constraintViolations = validator.validate( order );
+		Set<ConstraintViolation<Order>> constraintViolations = getValidator().validate( order );
 		assertCorrectNumberOfViolations( constraintViolations, 0 );
 	}
 
@@ -132,12 +125,12 @@ public class XmlConfigurationTest extends Arquillian {
 		user.setConsistent( true );
 		user.setFirstname( "Wolfeschlegelsteinhausenbergerdorff" );
 
-		Set<ConstraintViolation<User>> constraintViolations = validator.validate( user );
+		Set<ConstraintViolation<User>> constraintViolations = getValidator().validate( user );
 		assertCorrectNumberOfViolations( constraintViolations, 1 );
 		assertCorrectConstraintViolationMessages( constraintViolations, "Size is limited!" );
 
 		user.setFirstname( "Wolfgang" );
-		constraintViolations = validator.validate( user );
+		constraintViolations = getValidator().validate( user );
 		assertCorrectNumberOfViolations( constraintViolations, 0 );
 	}
 
@@ -156,14 +149,14 @@ public class XmlConfigurationTest extends Arquillian {
 		user.setFirstname( "Wolfgang" );
 		user.setLastname( "doe" );
 
-		Set<ConstraintViolation<User>> constraintViolations = validator.validate( user );
+		Set<ConstraintViolation<User>> constraintViolations = getValidator().validate( user );
 		assertCorrectNumberOfViolations( constraintViolations, 1 );
 		assertCorrectConstraintViolationMessages(
 				constraintViolations, "Last name has to start with with a capital letter."
 		);
 
 		user.setLastname( "Doe" );
-		constraintViolations = validator.validate( user );
+		constraintViolations = getValidator().validate( user );
 		assertCorrectNumberOfViolations( constraintViolations, 0 );
 	}
 
@@ -181,14 +174,14 @@ public class XmlConfigurationTest extends Arquillian {
 		user.setConsistent( true );
 		user.setPhoneNumber( "police" );
 
-		Set<ConstraintViolation<User>> constraintViolations = validator.validate( user );
+		Set<ConstraintViolation<User>> constraintViolations = getValidator().validate( user );
 		assertCorrectNumberOfViolations( constraintViolations, 1 );
 		assertCorrectConstraintViolationMessages(
 				constraintViolations, "A phone number can only contain numbers, whitespaces and dashes."
 		);
 
 		user.setPhoneNumber( "112" );
-		constraintViolations = validator.validate( user );
+		constraintViolations = getValidator().validate( user );
 		assertCorrectNumberOfViolations( constraintViolations, 0 );
 	}
 
@@ -208,12 +201,12 @@ public class XmlConfigurationTest extends Arquillian {
 		card.setNumber( "not a number" );
 		user.setCreditcard( card );
 
-		Set<ConstraintViolation<User>> constraintViolations = validator.validate( user );
+		Set<ConstraintViolation<User>> constraintViolations = getValidator().validate( user );
 		assertCorrectNumberOfViolations( constraintViolations, 1 );
 		assertCorrectConstraintViolationMessages( constraintViolations, "Not a credit card number." );
 
 		card.setNumber( "1234567890" );
-		constraintViolations = validator.validate( user );
+		constraintViolations = getValidator().validate( user );
 		assertCorrectNumberOfViolations( constraintViolations, 0 );
 	}
 
@@ -221,7 +214,7 @@ public class XmlConfigurationTest extends Arquillian {
 	@SpecAssertion(section = "5.5.6", id = "o")
 	public void testMappingFilesAddedViaConfigurationGetAddedToXmlConfiguredMappings() {
 		assertFalse(
-				validator.getConstraintsForClass( Order.class ).isBeanConstrained(),
+				getValidator().getConstraintsForClass( Order.class ).isBeanConstrained(),
 				"Without additional mapping Order should be unconstrained"
 		);
 
@@ -260,7 +253,7 @@ public class XmlConfigurationTest extends Arquillian {
 			@SpecAssertion(section = "8.1.3", id = "k")
 	})
 	public void testElementConversionInXmlConfiguredConstraint() {
-		BeanDescriptor beanDescriptor = validator.getConstraintsForClass( User.class );
+		BeanDescriptor beanDescriptor = getValidator().getConstraintsForClass( User.class );
 		assertTrue( beanDescriptor.isBeanConstrained() );
 
 		Set<ConstraintDescriptor<?>> constraintDescriptors = beanDescriptor.getConstraintDescriptors();

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/util/TestUtil.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/util/TestUtil.java
@@ -39,6 +39,10 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.FileAssert.fail;
 
+import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
+import org.hibernate.beanvalidation.tck.tests.BaseValidatorTest;
+import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
+
 /**
  * @author Hardy Ferentschik
  * @author Gunnar Morling
@@ -383,6 +387,14 @@ public final class TestUtil {
 			inputStream = TestUtil.class.getResourceAsStream( path );
 		}
 		return inputStream;
+	}
+
+	public static WebArchiveBuilder webArchiveBuilder() {
+		return new WebArchiveBuilder().withClasses(
+				BaseExecutableValidatorTest.class,
+				BaseValidatorTest.class,
+				WebArchiveBuilder.class
+		);
 	}
 
 	private static <U extends ValidationProvider<?>> void instantiateValidationProviderUnderTest() {


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/BVTCK-57

I've replaced those before methods which were preparing validators with `BaseExecutableValidatorTest` and `BaseValidatorTest` classes. Adding  `webArchiveBuilder` util method was caused by the `java.lang.ClassNotFoundException` when running tests from setup-examples/maven.

One more `@BeforeMethod` remains in `ExpressionLanguageMessageInterpolationTest` where it is used for setting up a locale. 