### PR TITLE
BVTCK-57 Followup: Avoid the use of @BeforeMethod

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -13,7 +13,13 @@
 
 <module name="Checker">
 
+    <!-- Allows usage of CHECKSTYLE:ON/OFF in code to suppress violations within a pair of comments -->
+    <module name="SuppressionCommentFilter"/>
+
     <module name="TreeWalker">
+
+        <!-- SuppressionCommentFilter filter only works in conjunction with a FileContentsHolder -->
+        <module name="FileContentsHolder"/>
 
         <!-- Checks for imports -->
         <module name="AvoidStarImport"/>
@@ -25,8 +31,5 @@
         </module>
 
     </module>
-
-    <!--&lt;!&ndash; Checks that a file ends with a new line  &ndash;&gt;-->
-    <!--<module name="NewlineAtEndOfFile"/>-->
 
 </module>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Bean Validation TCK
+
+    License: Apache License, Version 2.0
+    See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+
+-->
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+
+    <module name="TreeWalker">
+
+        <!-- Checks for imports -->
+        <module name="AvoidStarImport"/>
+        <module name="RedundantImport"/>
+        <module name="UnusedImports"/>
+
+        <module name="ImportControl">
+            <property name="file" value="import-control.xml"/>
+        </module>
+
+    </module>
+
+    <!--&lt;!&ndash; Checks that a file ends with a new line  &ndash;&gt;-->
+    <!--<module name="NewlineAtEndOfFile"/>-->
+
+</module>

--- a/import-control.xml
+++ b/import-control.xml
@@ -15,15 +15,4 @@
     <allow pkg=".*\.*" regex="true"/>
     <disallow class="org.testng.annotations.BeforeMethod"/>
     <disallow class="org.testng.annotations.AfterMethod"/>
-
-    <!-- For ExpressionLanguageMessageInterpolationTest to be able to change Locale -->
-    <subpackage name="beanvalidation">
-        <subpackage name="tck">
-            <subpackage name="tests">
-                <subpackage name="messageinterpolation">
-                    <allow pkg=".*\.*" regex="true"/>
-                </subpackage>
-            </subpackage>
-        </subpackage>
-    </subpackage>
 </import-control>

--- a/import-control.xml
+++ b/import-control.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Bean Validation TCK
+
+    License: Apache License, Version 2.0
+    See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+
+-->
+<!DOCTYPE import-control PUBLIC
+        "-//Puppy Crawl//DTD Import Control 1.2//EN"
+        "http://checkstyle.sourceforge.net/dtds/import_control_1_2.dtd">
+
+<import-control pkg="org.hibernate">
+    <allow pkg=".*\.*" regex="true"/>
+    <disallow class="org.testng.annotations.BeforeMethod"/>
+    <disallow class="org.testng.annotations.AfterMethod"/>
+
+    <!-- For ExpressionLanguageMessageInterpolationTest to be able to change Locale -->
+    <subpackage name="beanvalidation">
+        <subpackage name="tck">
+            <subpackage name="tests">
+                <subpackage name="messageinterpolation">
+                    <allow pkg=".*\.*" regex="true"/>
+                </subpackage>
+            </subpackage>
+        </subpackage>
+    </subpackage>
+</import-control>

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,9 @@
         <asciidoctorj-pdf.version>1.5.0-alpha.11</asciidoctorj-pdf.version>
 
         <beanvalidation-tck-parent.basedir>${project.basedir}</beanvalidation-tck-parent.basedir>
+
+        <!-- Checkstyle -->
+        <com.puppycrawl.tools.version>7.6</com.puppycrawl.tools.version>
     </properties>
 
     <dependencyManagement>
@@ -387,6 +390,37 @@
                             </pluginExecutions>
                         </lifecycleMappingMetadata>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <version>2.17</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.puppycrawl.tools</groupId>
+                            <artifactId>checkstyle</artifactId>
+                            <version>${com.puppycrawl.tools.version}</version>
+                        </dependency>
+                    </dependencies>
+                    <configuration>
+                        <configLocation>checkstyle.xml</configLocation>
+                        <consoleOutput>true</consoleOutput>
+                        <failsOnError>true</failsOnError>
+                        <violationSeverity>error</violationSeverity>
+                        <includeResources>true</includeResources>
+                        <includeTestResources>false</includeTestResources>
+                        <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                        <resourceIncludes>**/*.xml,**/*.properties</resourceIncludes>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>check-style</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -165,6 +165,10 @@
                     <compilerArgument>-parameters</compilerArgument>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/bootstrap/customprovider/BootstrapCustomProviderDefinedInServiceFileTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/bootstrap/customprovider/BootstrapCustomProviderDefinedInServiceFileTest.java
@@ -14,7 +14,6 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
-import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/application/method/MethodValidationRequirementTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/application/method/MethodValidationRequirementTest.java
@@ -21,7 +21,6 @@ import org.testng.annotations.Test;
 
 import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
 import org.hibernate.beanvalidation.tck.util.TestUtil;
-import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectConstraintTypes;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectNumberOfViolations;

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/crossparameter/GenericAndCrossParameterConstraintTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/crossparameter/GenericAndCrossParameterConstraintTest.java
@@ -19,7 +19,6 @@ import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
 import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
-import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectConstraintTypes;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectNumberOfViolations;

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/crossparameter/InvalidDeclarationOfGenericAndCrossParameterConstraintTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/crossparameter/InvalidDeclarationOfGenericAndCrossParameterConstraintTest.java
@@ -19,7 +19,6 @@ import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
 import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
-import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
 import static org.hibernate.beanvalidation.tck.util.TestUtil.webArchiveBuilder;
 import static org.testng.Assert.fail;

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/groups/groupconversion/InvalidGroupDefinitionsTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/groups/groupconversion/InvalidGroupDefinitionsTest.java
@@ -16,7 +16,6 @@ import javax.validation.ConstraintDeclarationException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
-import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
@@ -37,7 +36,6 @@ import org.hibernate.beanvalidation.tck.tests.constraints.groups.groupconversion
 import org.hibernate.beanvalidation.tck.tests.constraints.groups.groupconversion.service.impl.ImplementationOfParallelInterfacesWithGroupConversionOnReturnValue;
 import org.hibernate.beanvalidation.tck.tests.constraints.groups.groupconversion.service.impl.InterfaceImplementationWithGroupConversionOnParameter;
 import org.hibernate.beanvalidation.tck.tests.constraints.groups.groupconversion.service.impl.SubClassWithGroupConversionOnParameter;
-import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
 /**
  * Test for definition of group conversion rules.

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/inheritance/method/invaliddeclarations/InvalidMethodConstraintDeclarationTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/inheritance/method/invaliddeclarations/InvalidMethodConstraintDeclarationTest.java
@@ -14,7 +14,6 @@ import javax.validation.ConstraintDeclarationException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
-import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
@@ -33,7 +32,6 @@ import org.hibernate.beanvalidation.tck.tests.constraints.inheritance.method.inv
 import org.hibernate.beanvalidation.tck.tests.constraints.inheritance.method.invaliddeclarations.service.impl.SubClassAddingParameterConstraints;
 import org.hibernate.beanvalidation.tck.tests.constraints.inheritance.method.invaliddeclarations.service.impl.SubClassMarkingParameterAsCascaded;
 import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
-import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
 import static org.hibernate.beanvalidation.tck.util.TestUtil.webArchiveBuilder;
 import static org.testng.Assert.fail;

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/inheritance/method/validdeclarations/ValidMethodConstraintDeclarationTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/inheritance/method/validdeclarations/ValidMethodConstraintDeclarationTest.java
@@ -32,7 +32,6 @@ import org.hibernate.beanvalidation.tck.tests.constraints.inheritance.method.val
 import org.hibernate.beanvalidation.tck.tests.constraints.inheritance.method.validdeclarations.service.impl.ImplementationOfParallelInterfacesMarkingReturnValueAsCascaded;
 import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
 import org.hibernate.beanvalidation.tck.util.TestUtil;
-import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectConstraintTypes;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertNodeNames;

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/invalidconstraintdefinitions/InvalidConstraintDefinitionsTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/invalidconstraintdefinitions/InvalidConstraintDefinitionsTest.java
@@ -17,7 +17,6 @@ import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
 import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
-import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
 import static org.hibernate.beanvalidation.tck.util.TestUtil.webArchiveBuilder;
 import static org.testng.Assert.fail;

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/validatorresolution/ValidatorResolutionTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/validatorresolution/ValidatorResolutionTest.java
@@ -21,7 +21,6 @@ import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
 import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
-import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertConstraintViolation;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectConstraintTypes;

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/executable/global/ExecutableValidationBasedOnGlobalConfigurationTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/executable/global/ExecutableValidationBasedOnGlobalConfigurationTest.java
@@ -14,7 +14,6 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
-import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/executable/priority/Early.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/executable/priority/Early.java
@@ -10,8 +10,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import javax.interceptor.InterceptorBinding;
 
-import static java.lang.annotation.ElementType.*;
-import static java.lang.annotation.RetentionPolicy.*;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * @author Gunnar Morling

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/executable/priority/Late.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/executable/priority/Late.java
@@ -10,8 +10,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import javax.interceptor.InterceptorBinding;
 
-import static java.lang.annotation.ElementType.*;
-import static java.lang.annotation.RetentionPolicy.*;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * @author Gunnar Morling

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/messageinterpolation/ExpressionLanguageMessageInterpolationTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/messageinterpolation/ExpressionLanguageMessageInterpolationTest.java
@@ -26,9 +26,11 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+// CHECKSTYLE:OFF
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+// CHECKSTYLE:ON
 
 import org.hibernate.beanvalidation.tck.tests.BaseValidatorTest;
 import org.hibernate.beanvalidation.tck.util.TestUtil;

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/messageinterpolation/ExpressionLanguageMessageInterpolationTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/messageinterpolation/ExpressionLanguageMessageInterpolationTest.java
@@ -32,7 +32,6 @@ import org.testng.annotations.Test;
 
 import org.hibernate.beanvalidation.tck.tests.BaseValidatorTest;
 import org.hibernate.beanvalidation.tck.util.TestUtil;
-import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/MethodValidationTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/MethodValidationTest.java
@@ -38,7 +38,6 @@ import org.hibernate.beanvalidation.tck.tests.methodvalidation.service.OrderServ
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.service.OrderServiceWithRedefinedDefaultGroupSequence;
 import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
 import org.hibernate.beanvalidation.tck.util.TestUtil;
-import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectConstraintTypes;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectNumberOfViolations;

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ValidateConstructorParametersTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ValidateConstructorParametersTest.java
@@ -31,7 +31,6 @@ import org.hibernate.beanvalidation.tck.tests.methodvalidation.model.User.Basic;
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.model.User.Extended;
 import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
 import org.hibernate.beanvalidation.tck.util.TestUtil;
-import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectConstraintTypes;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectNumberOfViolations;

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ValidateConstructorReturnValueTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ValidateConstructorReturnValueTest.java
@@ -31,7 +31,6 @@ import org.hibernate.beanvalidation.tck.tests.methodvalidation.model.Item;
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.model.OrderLine;
 import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
 import org.hibernate.beanvalidation.tck.util.TestUtil;
-import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectConstraintTypes;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectNumberOfViolations;

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ValidateParametersTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ValidateParametersTest.java
@@ -31,7 +31,6 @@ import org.hibernate.beanvalidation.tck.tests.methodvalidation.model.User.Basic;
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.model.User.Extended;
 import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
 import org.hibernate.beanvalidation.tck.util.TestUtil;
-import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectConstraintTypes;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectNumberOfViolations;

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ValidateReturnValueTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ValidateReturnValueTest.java
@@ -31,7 +31,6 @@ import org.hibernate.beanvalidation.tck.tests.methodvalidation.model.Item;
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.model.OrderLine;
 import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
 import org.hibernate.beanvalidation.tck.util.TestUtil;
-import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectConstraintTypes;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectNumberOfViolations;

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/GetterDefinitionTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/GetterDefinitionTest.java
@@ -18,7 +18,6 @@ import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
 import org.hibernate.beanvalidation.tck.tests.BaseValidatorTest;
-import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectConstraintTypes;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.webArchiveBuilder;

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/PropertyPathTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/PropertyPathTest.java
@@ -43,7 +43,6 @@ import org.testng.annotations.Test;
 
 import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
 import org.hibernate.beanvalidation.tck.util.TestUtil;
-import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/ValidatePropertyTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/ValidatePropertyTest.java
@@ -19,7 +19,6 @@ import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
 import org.hibernate.beanvalidation.tck.tests.BaseValidatorTest;
-import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertConstraintViolation;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectConstraintTypes;

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/ValueAccessStrategyTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/ValueAccessStrategyTest.java
@@ -22,7 +22,6 @@ import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
 import org.hibernate.beanvalidation.tck.tests.BaseValidatorTest;
-import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
 import static java.lang.annotation.ElementType.CONSTRUCTOR;
 import static java.lang.annotation.ElementType.FIELD;

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/groupconversion/GroupConversionValidationTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/groupconversion/GroupConversionValidationTest.java
@@ -25,7 +25,6 @@ import org.testng.annotations.Test;
 
 import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
 import org.hibernate.beanvalidation.tck.util.TestUtil;
-import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectNumberOfViolations;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectPropertyPaths;

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/XmlConfigurationTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/XmlConfigurationTest.java
@@ -25,7 +25,6 @@ import org.testng.annotations.Test;
 
 import org.hibernate.beanvalidation.tck.tests.BaseValidatorTest;
 import org.hibernate.beanvalidation.tck.util.TestUtil;
-import org.hibernate.beanvalidation.tck.util.shrinkwrap.WebArchiveBuilder;
 
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectConstraintViolationMessages;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectNumberOfViolations;


### PR DESCRIPTION
It's a follow up on 

- https://hibernate.atlassian.net/browse/BVTCK-57

As @gunnarmorling mentioned in the comments of https://github.com/beanvalidation/beanvalidation-tck/pull/86#issuecomment-287355830 I've added checkstyle plugin with configs for imports only. Turned out that there were a few violations so I've cleaned those up. 

Also with that last commit I've removed the last `Before/After`'s they were used to change `Locale`.

As enabling other checlstyle rules will require some code modifications (for example `NewlineAtEndOfFile` is failing in each file :) ), I think it'll be better if done separately from this one.
Let me know if that would be useful and if so - I can work on it :)