### PR TITLE
BVTCK-109 Update to validation-api 2.0.0.Alpha2 and HV 6.0.0.Alpha2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,8 +95,8 @@
         <!-- see http://maven.apache.org/general.html -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <validation.api.version>2.0.0-SNAPSHOT</validation.api.version>
-        <hibernate.validator.version>6.0.0-SNAPSHOT</hibernate.validator.version>
+        <validation.api.version>2.0.0.Alpha2</validation.api.version>
+        <hibernate.validator.version>6.0.0.Alpha2</hibernate.validator.version>
 
         <testng.version>6.11</testng.version>
 


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/BVTCK-109

The version of HV is only used in the doc so we can update it beforehand (thus breaking the circular dependency).