### PR TITLE
BVTCK-114 Add tests for the support of group conversion for container elements + BVTCK-116

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,11 +95,11 @@
         <!-- see http://maven.apache.org/general.html -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <validation.api.version>2.0.0.Alpha2</validation.api.version>
+        <validation.api.version>2.0.0.Beta1</validation.api.version>
 
         <!-- This is only needed for an example in the documentation; there is
              no dependency to the RI -->
-        <hibernate.validator.version>6.0.0.Alpha2</hibernate.validator.version>
+        <hibernate.validator.version>6.0.0-SNAPSHOT</hibernate.validator.version>
 
         <testng.version>6.11</testng.version>
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/metadata/ComplexOrder.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/metadata/ComplexOrder.java
@@ -1,0 +1,62 @@
+/**
+ * Bean Validation TCK
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.beanvalidation.tck.tests.metadata;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import javax.validation.groups.ConvertGroup;
+import javax.validation.groups.Default;
+
+/**
+ * @author Guillaume Smet
+ */
+public class ComplexOrder {
+	@NotNull(message = "Order number must be specified")
+	Integer orderNumber;
+
+	Map<
+			@Valid @NotNull
+			@ConvertGroup(from = Default.class, to = BasicChecks.class) @ConvertGroup(from = ComplexChecks.class, to = ComplexProductTypeChecks.class)
+			ProductType,
+			@Size(min = 2)
+			List<@NotNull ProductOrderLine>> orderLines;
+
+	public Integer getOrderNumber() {
+		return orderNumber;
+	}
+
+	public void setOrderNumber(Integer orderNumber) {
+		this.orderNumber = orderNumber;
+	}
+
+	public Map<ProductType, List<ProductOrderLine>> getOrderLines() {
+		return orderLines;
+	}
+
+	public void setOrderLines(Map<ProductType, List<ProductOrderLine>> orderLines) {
+		this.orderLines = orderLines;
+	}
+
+	public interface BasicChecks {
+	}
+
+	public interface ComplexChecks {
+	}
+
+	public interface ComplexProductTypeChecks {
+	}
+
+	public static class ProductType {
+	}
+
+	public static class ProductOrderLine {
+	}
+}

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/groupconversion/ContainerElementGroupConversionValidationTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/groupconversion/ContainerElementGroupConversionValidationTest.java
@@ -1,0 +1,381 @@
+/**
+ * Bean Validation TCK
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.beanvalidation.tck.tests.validation.groupconversion;
+
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.ConstraintViolationSetAssert.assertContainsOnlyPaths;
+import static org.hibernate.beanvalidation.tck.util.TestUtil.assertCorrectNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.TestUtil.assertDescriptorKinds;
+import static org.hibernate.beanvalidation.tck.util.TestUtil.assertNodeNames;
+import static org.hibernate.beanvalidation.tck.util.TestUtil.webArchiveBuilder;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.time.Year;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.ElementKind;
+import javax.validation.Path;
+import javax.validation.groups.Default;
+
+import org.hibernate.beanvalidation.tck.beanvalidation.Sections;
+import org.hibernate.beanvalidation.tck.tests.BaseExecutableValidatorTest;
+import org.hibernate.beanvalidation.tck.util.TestUtil;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
+/**
+ * @author Guillaume Smet
+ */
+@SpecVersion(spec = "beanvalidation", version = "2.0.0")
+public class ContainerElementGroupConversionValidationTest extends BaseExecutableValidatorTest {
+
+	@Deployment
+	public static WebArchive createTestArchive() {
+		return webArchiveBuilder()
+				.withTestClassPackage( ContainerElementGroupConversionValidationTest.class )
+				.build();
+	}
+
+	@Test
+	// FIXME: update spec assertions
+	@SpecAssertion(section = Sections.CONSTRAINTDECLARATIONVALIDATIONPROCESS_GROUPSEQUENCE_GROUPCONVERSION, id = "c")
+	@SpecAssertion(section = Sections.CONSTRAINTDECLARATIONVALIDATIONPROCESS_VALIDATIONROUTINE, id = "a")
+	public void testGroupConversionIsAppliedOnField() {
+		Set<ConstraintViolation<RegisteredAddresses>> constraintViolations = getValidator().validate( TestRegisteredAddresses.withInvalidMainAddress() );
+
+
+		assertContainsOnlyPaths( constraintViolations,
+				pathWith()
+						.property( "mainAddresses" )
+						.containerElement( "<map value>", true, TestRegisteredAddresses.REFERENCE_YEAR, null, Map.class, 1 )
+						.property( "street1", true, null, 1, List.class, 0 ),
+				pathWith()
+						.property( "mainAddresses" )
+						.containerElement( "<map value>", true, TestRegisteredAddresses.REFERENCE_YEAR, null, Map.class, 1 )
+						.property( "zipCode", true, null, 1, List.class, 0 )
+		);
+	}
+
+	@Test
+	// FIXME: update spec assertions
+	@SpecAssertion(section = Sections.CONSTRAINTDECLARATIONVALIDATIONPROCESS_GROUPSEQUENCE_GROUPCONVERSION, id = "c")
+	@SpecAssertion(section = Sections.CONSTRAINTDECLARATIONVALIDATIONPROCESS_VALIDATIONROUTINE, id = "a")
+	public void testSeveralGroupConversionsAppliedOnField() {
+		RegisteredAddresses registeredAddressesWithInvalidPreferredShipmentAddress = TestRegisteredAddresses.withInvalidPreferredShipmentAddress();
+
+		Set<ConstraintViolation<RegisteredAddresses>> constraintViolations = getValidator().validate(
+				registeredAddressesWithInvalidPreferredShipmentAddress
+		);
+
+		assertContainsOnlyPaths( constraintViolations,
+				pathWith()
+						.property( "preferredShipmentAddresses" )
+						.containerElement( "<map value>", true, TestRegisteredAddresses.REFERENCE_YEAR, null, Map.class, 1 )
+						.property( "street1", true, null, 1, List.class, 0 ),
+				pathWith()
+						.property( "preferredShipmentAddresses" )
+						.containerElement( "<map value>", true, TestRegisteredAddresses.REFERENCE_YEAR, null, Map.class, 1 )
+						.property( "zipCode", true, null, 1, List.class, 0 ) );
+
+		constraintViolations = getValidator().validate(
+				registeredAddressesWithInvalidPreferredShipmentAddress,
+				Complex.class
+		);
+
+		assertContainsOnlyPaths( constraintViolations,
+				pathWith()
+					.property( "preferredShipmentAddresses" )
+					.containerElement( "<map value>", true, TestRegisteredAddresses.REFERENCE_YEAR, null, Map.class, 1 )
+					.property("doorCode", true, null, 1, List.class, 0 )
+		);
+
+		constraintViolations = getValidator().validate(
+				registeredAddressesWithInvalidPreferredShipmentAddress,
+				Default.class,
+				Complex.class
+		);
+
+		assertContainsOnlyPaths( constraintViolations,
+				pathWith()
+						.property( "preferredShipmentAddresses" )
+						.containerElement( "<map value>", true, TestRegisteredAddresses.REFERENCE_YEAR, null, Map.class, 1 )
+						.property( "street1", true, null, 1, List.class, 0 ),
+				pathWith()
+						.property( "preferredShipmentAddresses" )
+						.containerElement( "<map value>", true, TestRegisteredAddresses.REFERENCE_YEAR, null, Map.class, 1 )
+						.property( "zipCode", true, null, 1, List.class, 0 ),
+				pathWith()
+						.property( "preferredShipmentAddresses" )
+						.containerElement( "<map value>", true, TestRegisteredAddresses.REFERENCE_YEAR, null, Map.class, 1 )
+						.property( "doorCode", true, null, 1, List.class, 0 )
+		);
+
+		constraintViolations = getValidator().validate(
+				registeredAddressesWithInvalidPreferredShipmentAddress,
+				Complete.class
+		);
+
+		assertContainsOnlyPaths( constraintViolations,
+				pathWith()
+						.property( "preferredShipmentAddresses" )
+						.containerElement( "<map value>", true, TestRegisteredAddresses.REFERENCE_YEAR, null, Map.class, 1 )
+						.property( "street1", true, null, 1, List.class, 0 ),
+				pathWith()
+						.property( "preferredShipmentAddresses" )
+						.containerElement( "<map value>", true, TestRegisteredAddresses.REFERENCE_YEAR, null, Map.class, 1 )
+						.property( "zipCode", true, null, 1, List.class, 0 ),
+				pathWith()
+						.property( "preferredShipmentAddresses" )
+						.containerElement( "<map value>", true, TestRegisteredAddresses.REFERENCE_YEAR, null, Map.class, 1 )
+						.property( "doorCode", true, null, 1, List.class, 0 )
+		);
+	}
+
+	@Test
+	// FIXME: update spec assertions
+	@SpecAssertion(section = Sections.CONSTRAINTDECLARATIONVALIDATIONPROCESS_GROUPSEQUENCE_GROUPCONVERSION, id = "c")
+	public void testGroupConversionIsAppliedOnProperty() {
+		Set<ConstraintViolation<RegisteredAddresses>> constraintViolations = getValidator().validate( TestRegisteredAddresses.withInvalidShipmentAddress() );
+
+		assertContainsOnlyPaths( constraintViolations,
+				pathWith()
+						.property( "shipmentAddresses" )
+						.containerElement( "<map value>", true, TestRegisteredAddresses.REFERENCE_YEAR, null, Map.class, 1 )
+						.property( "street1", true, null, 1, List.class, 0 ),
+				pathWith()
+						.property( "shipmentAddresses" )
+						.containerElement( "<map value>", true, TestRegisteredAddresses.REFERENCE_YEAR, null, Map.class, 1 )
+						.property( "zipCode", true, null, 1, List.class, 0 )
+		);
+	}
+
+	@Test
+	// FIXME: update spec assertions
+	@SpecAssertion(section = Sections.CONSTRAINTDECLARATIONVALIDATIONPROCESS_GROUPSEQUENCE_GROUPCONVERSION, id = "c")
+	public void testGroupConversionIsAppliedOnMethodReturnValue() throws Exception {
+		//given
+		RegisteredAddresses registeredAddresses = TestRegisteredAddresses.validRegisteredAddresses();
+		Method method = RegisteredAddresses.class.getMethod( "retrieveMainAddresses" );
+		Object returnValue = TestAddresses.wrap( TestAddresses.withInvalidStreet1() );
+
+		//when
+		Set<ConstraintViolation<RegisteredAddresses>> constraintViolations = getExecutableValidator()
+				.validateReturnValue( registeredAddresses, method, returnValue );
+
+		//then
+		assertCorrectNumberOfViolations( constraintViolations, 1 );
+
+		Path propertyPath = constraintViolations.iterator().next().getPropertyPath();
+
+		assertDescriptorKinds( propertyPath, ElementKind.METHOD, ElementKind.RETURN_VALUE, ElementKind.CONTAINER_ELEMENT, ElementKind.PROPERTY );
+		assertNodeNames( propertyPath, "retrieveMainAddresses", TestUtil.RETURN_VALUE_NODE_NAME, "<map value>", "street1" );
+	}
+
+	@Test
+	// FIXME: update spec assertions
+	@SpecAssertion(section = Sections.CONSTRAINTDECLARATIONVALIDATIONPROCESS_GROUPSEQUENCE_GROUPCONVERSION, id = "c")
+	public void testGroupConversionIsAppliedOnMethodParameter() throws Exception {
+		//given
+		RegisteredAddresses registeredAddresses = TestRegisteredAddresses.validRegisteredAddresses();
+		Method method = RegisteredAddresses.class.getMethod( "setMainAddress", Map.class );
+		Object[] arguments = new Object[] { TestAddresses.wrap( TestAddresses.withInvalidStreet1() ) };
+
+		//when
+		Set<ConstraintViolation<RegisteredAddresses>> constraintViolations = getExecutableValidator()
+				.validateParameters( registeredAddresses, method, arguments );
+
+		//then
+		assertCorrectNumberOfViolations( constraintViolations, 1 );
+
+		Path propertyPath = constraintViolations.iterator().next().getPropertyPath();
+
+		assertDescriptorKinds( propertyPath, ElementKind.METHOD, ElementKind.PARAMETER, ElementKind.CONTAINER_ELEMENT, ElementKind.PROPERTY );
+		assertNodeNames( propertyPath, "setMainAddress", "mainAddresses", "<map value>", "street1" );
+	}
+
+	@Test
+	// FIXME: update spec assertions
+	@SpecAssertion(section = Sections.CONSTRAINTDECLARATIONVALIDATIONPROCESS_GROUPSEQUENCE_GROUPCONVERSION, id = "c")
+	public void testGroupConversionIsAppliedOnConstructorReturnValue() throws Exception {
+		//given
+		Constructor<RegisteredAddresses> constructor = RegisteredAddresses.class.getConstructor( Map.class );
+		RegisteredAddresses createdObject = TestRegisteredAddresses.withMainAddressInvalidStreet1();
+
+		//when
+		Set<ConstraintViolation<RegisteredAddresses>> constraintViolations = getExecutableValidator()
+				.validateConstructorReturnValue( constructor, createdObject );
+
+		//then
+		assertCorrectNumberOfViolations( constraintViolations, 1 );
+
+		Path propertyPath = constraintViolations.iterator().next().getPropertyPath();
+
+		assertDescriptorKinds(
+				propertyPath,
+				ElementKind.CONSTRUCTOR,
+				ElementKind.RETURN_VALUE,
+				ElementKind.PROPERTY,
+				ElementKind.CONTAINER_ELEMENT,
+				ElementKind.PROPERTY
+		);
+		assertNodeNames( propertyPath, "RegisteredAddresses", TestUtil.RETURN_VALUE_NODE_NAME, "mainAddresses", "<map value>", "street1" );
+	}
+
+	@Test
+	// FIXME: update spec assertions
+	@SpecAssertion(section = Sections.CONSTRAINTDECLARATIONVALIDATIONPROCESS_GROUPSEQUENCE_GROUPCONVERSION, id = "c")
+	public void testGroupConversionIsAppliedOnConstructorParameter() throws Exception {
+		//given
+		Constructor<RegisteredAddresses> constructor = RegisteredAddresses.class.getConstructor( Map.class );
+		Object[] arguments = new Object[] { TestAddresses.wrap( TestAddresses.withInvalidStreet1() ) };
+
+		//when
+		Set<ConstraintViolation<RegisteredAddresses>> constraintViolations = getExecutableValidator()
+				.validateConstructorParameters( constructor, arguments );
+
+		//then
+		assertCorrectNumberOfViolations( constraintViolations, 1 );
+
+		Path propertyPath = constraintViolations.iterator().next().getPropertyPath();
+
+		assertDescriptorKinds( propertyPath, ElementKind.CONSTRUCTOR, ElementKind.PARAMETER, ElementKind.CONTAINER_ELEMENT, ElementKind.PROPERTY );
+		assertNodeNames( propertyPath, "RegisteredAddresses", "mainAddresses", "<map value>", "street1" );
+	}
+
+	@Test
+	// FIXME: update spec assertions
+	@SpecAssertion(section = Sections.CONSTRAINTDECLARATIONVALIDATIONPROCESS_GROUPSEQUENCE_GROUPCONVERSION, id = "d")
+	public void testGroupConversionIsNotExecutedRecursively() {
+		Set<ConstraintViolation<RegisteredAddresses>> constraintViolations = getValidator().validate( TestRegisteredAddresses.withInvalidOfficeAddress() );
+
+		assertContainsOnlyPaths( constraintViolations,
+				pathWith()
+						.property( "officeAddresses" )
+						.containerElement( "<map value>", true, TestRegisteredAddresses.REFERENCE_YEAR, null, Map.class, 1 )
+						.property( "street1", true, null, 1, List.class, 0 ),
+				pathWith()
+						.property( "officeAddresses" )
+						.containerElement( "<map value>", true, TestRegisteredAddresses.REFERENCE_YEAR, null, Map.class, 1 )
+						.property( "zipCode", true, null, 1, List.class, 0 )
+		);
+
+		constraintViolations = getValidator().validate(
+				TestRegisteredAddresses.withInvalidOfficeAddress(),
+				BasicPostal.class
+		);
+
+		assertContainsOnlyPaths( constraintViolations,
+				pathWith()
+						.property( "officeAddresses" )
+						.containerElement( "<map value>", true, TestRegisteredAddresses.REFERENCE_YEAR, null, Map.class, 1 )
+						.property( "doorCode", true, null, 1, List.class, 0 )
+		);
+	}
+
+	@Test
+	// FIXME: update spec assertions
+	@SpecAssertion(section = Sections.CONSTRAINTDECLARATIONVALIDATIONPROCESS_GROUPSEQUENCE_GROUPCONVERSION, id = "g")
+	public void testGroupConversionWithSequenceAsTo() {
+		RegisteredAddresses registeredAddresses = TestRegisteredAddresses.validRegisteredAddresses();
+
+		Set<ConstraintViolation<RegisteredAddresses>> constraintViolations = getValidator().validate( registeredAddresses );
+		assertCorrectNumberOfViolations( constraintViolations, 0 );
+
+		registeredAddresses.getWeekendAddresses().get( TestRegisteredAddresses.REFERENCE_YEAR ).get( 0 ).setDoorCode( "ABC" );
+		constraintViolations = getValidator().validate( registeredAddresses );
+		assertContainsOnlyPaths( constraintViolations,
+				pathWith()
+						.property( "weekendAddresses" )
+						.containerElement( "<map value>", true, TestRegisteredAddresses.REFERENCE_YEAR, null, Map.class, 1 )
+						.property( "doorCode", true, null, 0, List.class, 0 )
+		);
+
+		registeredAddresses.getWeekendAddresses().get( TestRegisteredAddresses.REFERENCE_YEAR ).get( 0 ).setStreet1( null );
+		constraintViolations = getValidator().validate( registeredAddresses );
+		assertContainsOnlyPaths( constraintViolations,
+				pathWith()
+						.property( "weekendAddresses" )
+						.containerElement( "<map value>", true, TestRegisteredAddresses.REFERENCE_YEAR, null, Map.class, 1 )
+						.property( "street1", true, null, 0, List.class, 0 ) );
+	}
+
+	private static class TestRegisteredAddresses {
+
+		public final static Year REFERENCE_YEAR = Year.of(2016);
+
+		public static RegisteredAddresses validRegisteredAddresses() {
+			return new RegisteredAddresses()
+					.addMainAddress( REFERENCE_YEAR, TestAddresses.validAddress() )
+					.addShipmentAddress( REFERENCE_YEAR, TestAddresses.validAddress() )
+					.addPreferredShipmentAddress( REFERENCE_YEAR, TestAddresses.validAddress() )
+					.addOfficeAddress( REFERENCE_YEAR, TestAddresses.validAddress() )
+					.addWeekendAddress( REFERENCE_YEAR, TestAddresses.validAddress() );
+		}
+
+		public static RegisteredAddresses withInvalidMainAddress() {
+			RegisteredAddresses registeredAddresses = validRegisteredAddresses();
+			registeredAddresses.addMainAddress( REFERENCE_YEAR, TestAddresses.invalidAddress() );
+			return registeredAddresses;
+		}
+
+		public static RegisteredAddresses withMainAddressInvalidStreet1() {
+			RegisteredAddresses registeredAddresses = validRegisteredAddresses();
+			registeredAddresses.addMainAddress( REFERENCE_YEAR, TestAddresses.withInvalidStreet1() );
+			return registeredAddresses;
+		}
+
+		public static RegisteredAddresses withInvalidShipmentAddress() {
+			RegisteredAddresses registeredAddresses = validRegisteredAddresses();
+			registeredAddresses.addShipmentAddress( REFERENCE_YEAR, TestAddresses.invalidAddress() );
+			return registeredAddresses;
+		}
+
+		public static RegisteredAddresses withInvalidPreferredShipmentAddress() {
+			RegisteredAddresses registeredAddresses = validRegisteredAddresses();
+			registeredAddresses.addPreferredShipmentAddress( REFERENCE_YEAR, TestAddresses.invalidAddress() );
+			return registeredAddresses;
+		}
+
+		public static RegisteredAddresses withInvalidOfficeAddress() {
+			RegisteredAddresses registeredAddresses = validRegisteredAddresses();
+			registeredAddresses.addOfficeAddress( REFERENCE_YEAR, TestAddresses.invalidAddress() );
+			return registeredAddresses;
+		}
+	}
+
+	private static class TestAddresses {
+
+		public static Address validAddress() {
+			return new Address( "Main Street", "c/o Hitchcock", "123", "AB" );
+		}
+
+		public static Address invalidAddress() {
+			return new Address( null, null, "12", "ABC" );
+		}
+
+		public static Address withInvalidStreet1() {
+			Address address = validAddress();
+			address.setStreet1( null );
+			return address;
+		}
+
+		public static Map<Year, List<Address>> wrap(Address address) {
+			Map<Year, List<Address>> addresses = new HashMap<>();
+			addresses.put( TestRegisteredAddresses.REFERENCE_YEAR, Arrays.asList( address ) );
+			return addresses;
+		}
+	}
+}

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/groupconversion/RegisteredAddresses.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/groupconversion/RegisteredAddresses.java
@@ -1,0 +1,106 @@
+/**
+ * Bean Validation TCK
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.beanvalidation.tck.tests.validation.groupconversion;
+
+import java.time.Year;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.validation.Valid;
+import javax.validation.groups.ConvertGroup;
+import javax.validation.groups.Default;
+
+/**
+ * @author Guillaume Smet
+ */
+public class RegisteredAddresses {
+
+	private final Map<Year, List<@Valid @ConvertGroup(from = Default.class, to = BasicPostal.class) Address>> mainAddresses = new HashMap<>();
+
+	private final Map<Year, List<Address>> shipmentAddresses = new HashMap<>();
+
+	private final Map<Year, List<@Valid
+			@ConvertGroup(from = Default.class, to = BasicPostal.class)
+			@ConvertGroup(from = Complex.class, to = ComplexPostal.class)
+	Address>> preferredShipmentAddresses = new HashMap<>();
+
+	private final Map<Year, List<@Valid
+			@ConvertGroup(from = Default.class, to = BasicPostal.class)
+			@ConvertGroup(from = BasicPostal.class, to = ComplexPostal.class)
+	Address>> officeAddresses = new HashMap<>();
+
+	private final Map<Year, List<@Valid @ConvertGroup(from = Default.class, to = PostalSequence.class) Address>> weekendAddresses = new HashMap<>();
+
+	public RegisteredAddresses() {
+	}
+
+	@Valid
+	@ConvertGroup(from = Default.class, to = BasicPostal.class)
+	public RegisteredAddresses(Map<Year, List<@Valid @ConvertGroup(from = Default.class, to = BasicPostal.class) Address>> mainAddresses) {
+		this.mainAddresses.putAll( mainAddresses );
+	}
+
+	public RegisteredAddresses addMainAddress(Year year, Address address) {
+		mainAddresses.computeIfAbsent( year, y -> new ArrayList<>() ).add( address );
+		return this;
+	}
+
+	public RegisteredAddresses addShipmentAddress(Year year, Address address) {
+		shipmentAddresses.computeIfAbsent( year, y -> new ArrayList<>() ).add( address );
+		return this;
+	}
+
+	public RegisteredAddresses addPreferredShipmentAddress(Year year, Address address) {
+		preferredShipmentAddresses.computeIfAbsent( year, y -> new ArrayList<>() ).add( address );
+		return this;
+	}
+
+	public RegisteredAddresses addOfficeAddress(Year year, Address address) {
+		officeAddresses.computeIfAbsent( year, y -> new ArrayList<>() ).add( address );
+		return this;
+	}
+
+	public RegisteredAddresses addWeekendAddress(Year year, Address address) {
+		weekendAddresses.computeIfAbsent( year, y -> new ArrayList<>() ).add( address );
+		return this;
+	}
+
+	public Map<Year, List<Address>> getMainAddresses() {
+		return mainAddresses;
+	}
+
+	public void setMainAddress(Map<Year, List<@Valid @ConvertGroup(from = Default.class, to = BasicPostal.class) Address>> mainAddresses) {
+		this.mainAddresses.clear();
+		this.mainAddresses.putAll( mainAddresses );
+	}
+
+	public Map<Year, List<Address>> getPreferredShipmentAddresses() {
+		return preferredShipmentAddresses;
+	}
+
+	public Map<Year, List<@Valid @ConvertGroup(from = Default.class, to = BasicPostal.class) Address>> getShipmentAddresses() {
+		return shipmentAddresses;
+	}
+
+	public Map<Year, List<Address>> getOfficeAddresses() {
+		return officeAddresses;
+	}
+
+	public Map<Year, List<Address>> getWeekendAddresses() {
+		return weekendAddresses;
+	}
+
+	public Map<Year, List<@Valid @ConvertGroup(from = Default.class, to = BasicPostal.class) Address>> retrieveMainAddresses() {
+		return mainAddresses;
+	}
+
+	public Map<Year, List<Address>> retrieveWeekendAddresses() {
+		return weekendAddresses;
+	}
+}

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/util/ConstraintViolationAssert.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/util/ConstraintViolationAssert.java
@@ -1,0 +1,390 @@
+/**
+ * Bean Validation TCK
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.beanvalidation.tck.util;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.ElementKind;
+import javax.validation.Path;
+
+/**
+ * This class provides useful functions to assert correctness of constraint violations raised
+ * during tests.
+ *
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
+ * @author Hardy Ferentschik
+ * @author Gunnar Morling
+ */
+public final class ConstraintViolationAssert {
+
+	/**
+	 * Expected name for cross-parameter nodes.
+	 */
+	private static final String CROSS_PARAMETER_NODE_NAME = "<cross-parameter>";
+
+	/**
+	 * Expected name for cross-parameter nodes.
+	 */
+	private static final String RETURN_VALUE_NODE_NAME = "<return value>";
+
+	/**
+	 * Private constructor in order to avoid instantiation.
+	 */
+	private ConstraintViolationAssert() {
+	}
+
+	public static PathExpectation pathWith() {
+		return new PathExpectation();
+	}
+
+	public static class ConstraintViolationSetAssert {
+
+		public static void assertContainsOnlyPaths(Set<? extends ConstraintViolation<?>> actualViolations, PathExpectation... paths) {
+			assertNotNull( paths );
+
+			List<PathExpectation> actualPaths = new ArrayList<>();
+
+			for ( ConstraintViolation<?> violation : actualViolations ) {
+				actualPaths.add( new PathExpectation( violation.getPropertyPath() ) );
+			}
+
+			assertContainsOnly( actualPaths, paths );
+		}
+
+		public static void assertContainsPath(Set<? extends ConstraintViolation<?>> actualViolations, PathExpectation expectedPath) {
+			assertNotNull( expectedPath );
+
+			List<PathExpectation> actualPaths = new ArrayList<>();
+			for ( ConstraintViolation<?> violation : actualViolations ) {
+				PathExpectation actual = new PathExpectation( violation.getPropertyPath() );
+				if ( actual.equals( expectedPath ) ) {
+					return;
+				}
+				actualPaths.add( actual );
+			}
+
+			fail( String.format( "Didn't find path <%s> in actual paths <%s>.", expectedPath, actualPaths ) );
+		}
+
+		public static void assertContainsPaths(Set<? extends ConstraintViolation<?>> actualViolations, PathExpectation... expectedPaths) {
+			for ( PathExpectation pathExpectation : expectedPaths ) {
+				assertContainsPath( actualViolations, pathExpectation );
+			}
+		}
+	}
+
+	private static void assertContainsOnly(Collection<?> actual, Object[] expected) {
+		assertNotNull( actual );
+		assertNotNull( expected );
+
+		if ( expected.length == actual.size() ) {
+			boolean equal = true;
+			for ( Object expectedElement : expected ) {
+				if ( !actual.contains( expectedElement ) ) {
+					equal = false;
+				}
+			}
+			if ( equal ) {
+				return;
+			}
+		}
+
+		fail( String.format( "Should only contain the expected element: <%s>. Actual: <%s>.", Arrays.toString( expected ), actual ) );
+	}
+
+	/**
+	 * A property path expected to be returned by a given {@link ConstraintViolation}.
+	 */
+	public static class PathExpectation {
+
+		private final List<NodeExpectation> nodes = new ArrayList<>();
+
+		private PathExpectation() {
+		}
+
+		private PathExpectation(Path propertyPath) {
+			for ( Path.Node node : propertyPath ) {
+				Integer parameterIndex = null;
+				if ( node.getKind() == ElementKind.PARAMETER ) {
+					parameterIndex = node.as( Path.ParameterNode.class ).getParameterIndex();
+				}
+				Class<?> containerClass = getContainerClass( node );
+				Integer typeArgumentIndex = getTypeArgumentIndex( node );
+				nodes.add(
+						new NodeExpectation(
+								node.getName(),
+								node.getKind(),
+								node.isInIterable(),
+								node.getKey(),
+								node.getIndex(),
+								parameterIndex,
+								containerClass,
+								typeArgumentIndex
+						)
+				);
+			}
+		}
+
+		public PathExpectation property(String name) {
+			nodes.add( new NodeExpectation( name, ElementKind.PROPERTY ) );
+			return this;
+		}
+
+		public PathExpectation property(String name, Class<?> containerClass, Integer typeArgumentIndex) {
+			nodes.add( new NodeExpectation( name, ElementKind.PROPERTY, false, null, null, null, containerClass, typeArgumentIndex ) );
+			return this;
+		}
+
+		public PathExpectation property(String name, boolean inIterable, Object key, Integer index) {
+			nodes.add( new NodeExpectation( name, ElementKind.PROPERTY, inIterable, key, index, null, null, null ) );
+			return this;
+		}
+
+		public PathExpectation property(String name, boolean inIterable, Object key, Integer index, Class<?> containerClass, Integer typeArgumentIndex) {
+			nodes.add( new NodeExpectation( name, ElementKind.PROPERTY, inIterable, key, index, null, containerClass, typeArgumentIndex ) );
+			return this;
+		}
+
+		public PathExpectation bean() {
+			nodes.add( new NodeExpectation( null, ElementKind.BEAN ) );
+			return this;
+		}
+
+		public PathExpectation bean(boolean inIterable, Object key, Integer index) {
+			nodes.add( new NodeExpectation( null, ElementKind.BEAN, inIterable, key, index, null, null, null ) );
+			return this;
+		}
+
+		public PathExpectation bean(boolean inIterable, Object key, Integer index, Class<?> containerClass, Integer typeArgumentIndex) {
+			nodes.add( new NodeExpectation( null, ElementKind.BEAN, inIterable, key, index, null, containerClass, typeArgumentIndex ) );
+			return this;
+		}
+
+		public PathExpectation method(String name) {
+			nodes.add( new NodeExpectation( name, ElementKind.METHOD ) );
+			return this;
+		}
+
+		public PathExpectation parameter(String name, int index) {
+			nodes.add( new NodeExpectation( name, ElementKind.PARAMETER, false, null, null, index, null, null ) );
+			return this;
+		}
+
+		public PathExpectation crossParameter() {
+			nodes.add( new NodeExpectation( CROSS_PARAMETER_NODE_NAME, ElementKind.CROSS_PARAMETER ) );
+			return this;
+		}
+
+		public PathExpectation returnValue() {
+			nodes.add( new NodeExpectation( RETURN_VALUE_NODE_NAME, ElementKind.RETURN_VALUE ) );
+			return this;
+		}
+
+		public PathExpectation containerElement(String name, boolean inIterable, Object key, Integer index, Class<?> containerClass, Integer typeArgumentIndex) {
+			nodes.add( new NodeExpectation( name, ElementKind.CONTAINER_ELEMENT, inIterable, key, index, null, containerClass, typeArgumentIndex ) );
+			return this;
+		}
+
+		@Override
+		public String toString() {
+			String lineBreak = System.getProperty( "line.separator" );
+			StringBuilder asString = new StringBuilder( lineBreak + "PathExpectation(" + lineBreak );
+			for ( NodeExpectation node : nodes ) {
+				asString.append( "  " ).append( node ).append( lineBreak );
+			}
+
+			return asString.append( ")" ).toString();
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + ( ( nodes == null ) ? 0 : nodes.hashCode() );
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if ( this == obj ) {
+				return true;
+			}
+			if ( obj == null ) {
+				return false;
+			}
+			if ( getClass() != obj.getClass() ) {
+				return false;
+			}
+			PathExpectation other = (PathExpectation) obj;
+			if ( nodes == null ) {
+				if ( other.nodes != null ) {
+					return false;
+				}
+			}
+			else if ( !nodes.equals( other.nodes ) ) {
+				return false;
+			}
+			return true;
+		}
+	}
+
+	/**
+	 * A node expected to be contained in the property path returned by a given {@link ConstraintViolation}.
+	 */
+	private static class NodeExpectation {
+		private final String name;
+		private final ElementKind kind;
+		private final boolean inIterable;
+		private final Object key;
+		private final Integer index;
+		private final Integer parameterIndex;
+		private final Class<?> containerClass;
+		private final Integer typeArgumentIndex;
+
+		private NodeExpectation(String name, ElementKind kind) {
+			this( name, kind, false, null, null, null, null, null );
+		}
+
+		private NodeExpectation(String name, ElementKind kind, boolean inIterable, Object key, Integer index,
+				Integer parameterIndex, Class<?> containerClass, Integer typeArgumentIndex) {
+			this.name = name;
+			this.kind = kind;
+			this.inIterable = inIterable;
+			this.key = key;
+			this.index = index;
+			this.parameterIndex = parameterIndex;
+			this.containerClass = containerClass;
+			this.typeArgumentIndex = typeArgumentIndex;
+		}
+
+		@Override
+		public String toString() {
+			return "NodeExpectation(" + name + ", " + kind + ", " + inIterable
+					+ ", " + key + ", " + index + ", " + parameterIndex + ", " + containerClass + ", " + typeArgumentIndex + ")";
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + ( inIterable ? 1231 : 1237 );
+			result = prime * result + ( ( index == null ) ? 0 : index.hashCode() );
+			result = prime * result + ( ( key == null ) ? 0 : key.hashCode() );
+			result = prime * result + ( ( kind == null ) ? 0 : kind.hashCode() );
+			result = prime * result + ( ( name == null ) ? 0 : name.hashCode() );
+			result = prime * result + ( ( parameterIndex == null ) ? 0 : parameterIndex.hashCode() );
+			result = prime * result + ( ( containerClass == null ) ? 0 : containerClass.hashCode() );
+			result = prime * result + ( ( typeArgumentIndex == null ) ? 0 : typeArgumentIndex.hashCode() );
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if ( this == obj ) {
+				return true;
+			}
+			if ( obj == null ) {
+				return false;
+			}
+			if ( getClass() != obj.getClass() ) {
+				return false;
+			}
+			NodeExpectation other = (NodeExpectation) obj;
+			if ( inIterable != other.inIterable ) {
+				return false;
+			}
+			if ( index == null ) {
+				if ( other.index != null ) {
+					return false;
+				}
+			}
+			else if ( !index.equals( other.index ) ) {
+				return false;
+			}
+			if ( key == null ) {
+				if ( other.key != null ) {
+					return false;
+				}
+			}
+			else if ( !key.equals( other.key ) ) {
+				return false;
+			}
+			if ( kind != other.kind ) {
+				return false;
+			}
+			if ( name == null ) {
+				if ( other.name != null ) {
+					return false;
+				}
+			}
+			else if ( !name.equals( other.name ) ) {
+				return false;
+			}
+			if ( parameterIndex == null ) {
+				if ( other.parameterIndex != null ) {
+					return false;
+				}
+			}
+			else if ( !parameterIndex.equals( other.parameterIndex ) ) {
+				return false;
+			}
+			if ( containerClass == null ) {
+				if ( other.containerClass != null ) {
+					return false;
+				}
+			}
+			else if ( !containerClass.equals( other.containerClass ) ) {
+				return false;
+			}
+			if ( typeArgumentIndex == null ) {
+				if ( other.typeArgumentIndex != null ) {
+					return false;
+				}
+			}
+			else if ( !typeArgumentIndex.equals( other.typeArgumentIndex ) ) {
+				return false;
+			}
+			return true;
+		}
+	}
+
+	private static Class<?> getContainerClass(Path.Node node) {
+		Class<?> containerClass = null;
+		if ( node.getKind() == ElementKind.PROPERTY ) {
+			containerClass = node.as( Path.PropertyNode.class ).getContainerClass();
+		}
+		if ( node.getKind() == ElementKind.BEAN ) {
+			containerClass = node.as( Path.BeanNode.class ).getContainerClass();
+		}
+		if ( node.getKind() == ElementKind.CONTAINER_ELEMENT ) {
+			containerClass = node.as( Path.ContainerElementNode.class ).getContainerClass();
+		}
+		return containerClass;
+	}
+
+	private static Integer getTypeArgumentIndex(Path.Node node) {
+		Integer typeArgumentIndex = null;
+		if ( node.getKind() == ElementKind.PROPERTY ) {
+			typeArgumentIndex = node.as( Path.PropertyNode.class ).getTypeArgumentIndex();
+		}
+		if ( node.getKind() == ElementKind.BEAN ) {
+			typeArgumentIndex = node.as( Path.BeanNode.class ).getTypeArgumentIndex();
+		}
+		if ( node.getKind() == ElementKind.CONTAINER_ELEMENT ) {
+			typeArgumentIndex = node.as( Path.ContainerElementNode.class ).getTypeArgumentIndex();
+		}
+		return typeArgumentIndex;
+	}
+}


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/BVTCK-114
 * https://hibernate.atlassian.net/browse/BVTCK-116

Added to the TCK as it reused the same classes as for the original group conversion support.

I'll need to update the assertions once they are added to the BV spec.