### PR TITLE
BVTCK-116 Add tests for container element constraints metadata support

### DIFF
--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/metadata/Order.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/metadata/Order.java
@@ -6,14 +6,29 @@
  */
 package org.hibernate.beanvalidation.tck.tests.metadata;
 
+import java.util.List;
+import java.util.Map;
+
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import javax.validation.groups.ConvertGroup;
+import javax.validation.groups.Default;
 
 /**
  * @author Hardy Ferentschik
+ * @author Guillaume Smet
  */
 public class Order {
 	@NotNull(message = "Order number must be specified")
 	Integer orderNumber;
+
+	Map<
+			@Valid @NotNull
+			@ConvertGroup(from = Default.class, to = BasicChecks.class) @ConvertGroup(from = ComplexChecks.class, to = ComplexProductTypeChecks.class)
+			ProductType,
+			@Size(min = 2)
+			List<@NotNull ProductOrderLine>> orderLines;
 
 	public Integer getOrderNumber() {
 		return orderNumber;
@@ -21,5 +36,28 @@ public class Order {
 
 	public void setOrderNumber(Integer orderNumber) {
 		this.orderNumber = orderNumber;
+	}
+
+	public Map<ProductType, List<ProductOrderLine>> getOrderLines() {
+		return orderLines;
+	}
+
+	public void setOrderLines(Map<ProductType, List<ProductOrderLine>> orderLines) {
+		this.orderLines = orderLines;
+	}
+
+	public interface BasicChecks {
+	}
+
+	public interface ComplexChecks {
+	}
+
+	public interface ComplexProductTypeChecks {
+	}
+
+	public static class ProductType {
+	}
+
+	public static class ProductOrderLine {
 	}
 }

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/metadata/PropertyDescriptorTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/metadata/PropertyDescriptorTest.java
@@ -13,9 +13,13 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
+import java.util.List;
 import java.util.Set;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import javax.validation.groups.Default;
+import javax.validation.metadata.ContainerElementTypeDescriptor;
 import javax.validation.metadata.GroupConversionDescriptor;
 import javax.validation.metadata.PropertyDescriptor;
 
@@ -150,5 +154,48 @@ public class PropertyDescriptorTest extends Arquillian {
 
 		assertNotNull( groupConversions );
 		assertTrue( groupConversions.isEmpty() );
+	}
+
+	@Test
+	// FIXME: update spec assertions
+	public void testGetContainerElementTypes() {
+		PropertyDescriptor descriptor = getPropertyDescriptor( Order.class, "orderLines" );
+
+		List<ContainerElementTypeDescriptor> containerElementTypes = descriptor.getContainerElementTypes();
+
+		ContainerElementTypeDescriptor productType = containerElementTypes.get( 0 );
+		assertEquals( productType.getTypeArgumentIndex().intValue(), 0 );
+		assertEquals( productType.getConstraintDescriptors().iterator().next().getAnnotation().annotationType(), NotNull.class );
+		assertEquals( productType.getContainerElementTypes().size(), 0 );
+		assertTrue( productType.isCascaded() );
+		assertEquals( productType.getGroupConversions().size(), 2 );
+		for ( GroupConversionDescriptor groupConversionDescriptor : productType.getGroupConversions() ) {
+			if ( groupConversionDescriptor.getFrom().equals( Default.class ) ) {
+				assertEquals( groupConversionDescriptor.getTo(), Order.BasicChecks.class );
+			}
+			else if ( groupConversionDescriptor.getFrom().equals( Order.ComplexChecks.class ) ) {
+				assertEquals( groupConversionDescriptor.getTo(), Order.ComplexProductTypeChecks.class );
+			}
+			else {
+				fail(
+						String.format(
+								"Encountered unexpected group conversion from %s to %s",
+								groupConversionDescriptor.getFrom().getName(),
+								groupConversionDescriptor.getTo().getName() ) );
+			}
+		}
+
+		ContainerElementTypeDescriptor orderLineList = containerElementTypes.get( 1 );
+		assertEquals( orderLineList.getTypeArgumentIndex().intValue(), 1 );
+		assertEquals( orderLineList.getConstraintDescriptors().iterator().next().getAnnotation().annotationType(), Size.class );
+		assertFalse( orderLineList.isCascaded() );
+		assertEquals( orderLineList.getGroupConversions().size(), 0 );
+		assertEquals( orderLineList.getContainerElementTypes().size(), 1 );
+
+		ContainerElementTypeDescriptor orderLine = orderLineList.getContainerElementTypes().get( 0 );
+		assertEquals( orderLine.getTypeArgumentIndex().intValue(), 0 );
+		assertEquals( orderLine.getConstraintDescriptors().iterator().next().getAnnotation().annotationType(), NotNull.class );
+		assertEquals( orderLine.getContainerElementTypes().size(), 0 );
+		assertFalse( orderLine.isCascaded() );
 	}
 }


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/BVTCK-116

First test added. I'll see what I can add tomorrow.

CI is red because it needs the BV upgrade commit present in: https://github.com/beanvalidation/beanvalidation-tck/pull/98 .