### PR TITLE
BVTCK-127 Use containsExactlyInAnyOrder for containsOnlyPaths

### DIFF
--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/MethodValidationTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/MethodValidationTest.java
@@ -798,6 +798,9 @@ public class MethodValidationTest extends AbstractTCKTest {
 						.returnValue(),
 				pathWith()
 						.method( methodName )
+						.returnValue(),
+				pathWith()
+						.method( methodName )
 						.returnValue()
 						.property( "name" )
 		);
@@ -831,6 +834,9 @@ public class MethodValidationTest extends AbstractTCKTest {
 				Size.class
 		);
 		assertThat( violations ).containsOnlyPaths(
+				pathWith()
+						.method( methodName )
+						.returnValue(),
 				pathWith()
 						.method( methodName )
 						.returnValue(),

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ValidateConstructorParametersTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ValidateConstructorParametersTest.java
@@ -165,6 +165,9 @@ public class ValidateConstructorParametersTest extends AbstractTCKTest {
 		assertThat( violations ).containsOnlyPaths(
 				pathWith()
 						.constructor( User.class )
+						.parameter( "firstName", 0 ),
+				pathWith()
+						.constructor( User.class )
 						.parameter( "firstName", 0 )
 		);
 	}
@@ -216,6 +219,9 @@ public class ValidateConstructorParametersTest extends AbstractTCKTest {
 				MyCrossParameterConstraint.class
 		);
 		assertThat( violations ).containsOnlyPaths(
+				pathWith()
+						.constructor( User.class )
+						.crossParameter(),
 				pathWith()
 						.constructor( User.class )
 						.crossParameter()

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ValidateConstructorReturnValueTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ValidateConstructorReturnValueTest.java
@@ -110,6 +110,9 @@ public class ValidateConstructorReturnValueTest extends AbstractTCKTest {
 		assertThat( violations ).containsOnlyPaths(
 				pathWith()
 						.constructor( Customer.class )
+						.returnValue(),
+				pathWith()
+						.constructor( Customer.class )
 						.returnValue()
 		);
 	}
@@ -129,6 +132,9 @@ public class ValidateConstructorReturnValueTest extends AbstractTCKTest {
 
 		assertCorrectConstraintTypes( violations, ValidCustomer.class, ValidCustomer.class );
 		assertThat( violations ).containsOnlyPaths(
+				pathWith()
+						.constructor( Customer.class )
+						.returnValue(),
 				pathWith()
 						.constructor( Customer.class )
 						.returnValue()
@@ -198,6 +204,9 @@ public class ValidateConstructorReturnValueTest extends AbstractTCKTest {
 
 		assertCorrectConstraintTypes( violations, ValidCustomer.class, ValidBusinessCustomer.class );
 		assertThat( violations ).containsOnlyPaths(
+				pathWith()
+						.constructor( Customer.class )
+						.returnValue(),
 				pathWith()
 						.constructor( Customer.class )
 						.returnValue()

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ValidateParametersTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ValidateParametersTest.java
@@ -177,6 +177,9 @@ public class ValidateParametersTest extends AbstractTCKTest {
 		assertThat( violations ).containsOnlyPaths(
 				pathWith()
 						.method( methodName )
+						.parameter( "firstName", 0 ),
+				pathWith()
+						.method( methodName )
 						.parameter( "firstName", 0 )
 		);
 	}
@@ -200,6 +203,9 @@ public class ValidateParametersTest extends AbstractTCKTest {
 
 		assertCorrectConstraintTypes( violations, Size.class, Size.class );
 		assertThat( violations ).containsOnlyPaths(
+				pathWith()
+						.method( methodName )
+						.parameter( "lastName", 0 ),
 				pathWith()
 						.method( methodName )
 						.parameter( "lastName", 0 )
@@ -234,6 +240,9 @@ public class ValidateParametersTest extends AbstractTCKTest {
 				MyCrossParameterConstraint.class
 		);
 		assertThat( violations ).containsOnlyPaths(
+				pathWith()
+						.method( methodName )
+						.crossParameter(),
 				pathWith()
 						.method( methodName )
 						.crossParameter()

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/util/ConstraintViolationAssert.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/util/ConstraintViolationAssert.java
@@ -11,7 +11,7 @@ import static org.testng.Assert.fail;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
@@ -68,7 +68,7 @@ public final class ConstraintViolationAssert {
 			actualMessages.add( violation.getMessage() );
 		}
 
-		Assertions.assertThat( actualMessages ).containsOnly( expectedMessages );
+		Assertions.assertThat( actualMessages ).containsExactlyInAnyOrder( expectedMessages );
 	}
 
 	public static void assertCorrectConstraintViolationMessages(ConstraintViolationException e,
@@ -222,24 +222,10 @@ public final class ConstraintViolationAssert {
 	 */
 	private static <T> void assertCorrectConstraintTypes(Iterable<Class<? extends Annotation>> actualConstraintTypes,
 			Class<?>... expectedConstraintTypes) {
-		List<String> expectedConstraintTypeNames = new ArrayList<>();
-		for ( Class<?> expectedConstraintType : expectedConstraintTypes ) {
-			expectedConstraintTypeNames.add( expectedConstraintType.getName() );
-		}
 
-		List<String> actualConstraintTypeNames = new ArrayList<>();
-		for ( Class<?> actualConstraintType : actualConstraintTypes ) {
-			actualConstraintTypeNames.add( actualConstraintType.getName() );
-		}
-
-		Collections.sort( expectedConstraintTypeNames );
-		Collections.sort( actualConstraintTypeNames );
-
-		assertEquals(
-				actualConstraintTypeNames,
-				expectedConstraintTypeNames,
-				String.format( "Expected %s, but got %s", expectedConstraintTypeNames, actualConstraintTypeNames )
-		);
+		Assertions.assertThat( actualConstraintTypes )
+				.extracting( Class::getName )
+				.containsExactlyInAnyOrder( Arrays.stream( expectedConstraintTypes ).map( clazz -> clazz.getName() ).toArray( size -> new String[size] ) );
 	}
 
 	public static PathExpectation pathWith() {
@@ -261,7 +247,7 @@ public final class ConstraintViolationAssert {
 				actualPaths.add( new PathExpectation( violation.getPropertyPath() ) );
 			}
 
-			Assertions.assertThat( actualPaths ).containsOnly( paths );
+			Assertions.assertThat( actualPaths ).containsExactlyInAnyOrder( paths );
 		}
 
 		public void containsPath(PathExpectation expectedPath) {


### PR DESCRIPTION
And a couple more Assertj related changes.

 * https://hibernate.atlassian.net/browse/BVTCK-127