### PR TITLE
BVTCK-132 Add tests for section 4 - Value extractor definition

### DIFF
--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/builtin/IterableValueExtractorTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/builtin/IterableValueExtractorTest.java
@@ -1,0 +1,79 @@
+/**
+ * Bean Validation TCK
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.beanvalidation.tck.tests.valueextraction.builtin;
+
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validator;
+import javax.validation.constraints.NotNull;
+
+import org.hibernate.beanvalidation.tck.beanvalidation.Sections;
+import org.hibernate.beanvalidation.tck.tests.AbstractTCKTest;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
+/**
+ * @author Guillaume Smet
+ */
+@SpecVersion(spec = "beanvalidation", version = "2.0.0")
+public class IterableValueExtractorTest extends AbstractTCKTest {
+
+	@Deployment
+	public static WebArchive createTestArchive() {
+		return webArchiveBuilder()
+				.withTestClass( IterableValueExtractorTest.class )
+				.build();
+	}
+
+	@Test
+	@SpecAssertion(section = Sections.VALUEEXTRACTORDEFINITION_BUILTINVALUEEXTRACTORS, id = "a")
+	public void iterableValueExtractor() {
+		Validator validator = getValidator();
+
+		Set<ConstraintViolation<IterableHolder>> violations = validator.validate( new IterableHolder( new IterableImpl<>( Arrays.asList( "valid", null ) ) ) );
+
+		assertThat( violations ).containsOnlyPaths(
+				pathWith()
+						.property( "iterable" )
+						.containerElement( "<iterable element>", true, null, null, Iterable.class, 0 )
+		);
+	}
+
+	private static class IterableHolder {
+
+		@SuppressWarnings("unused")
+		private final Iterable<@NotNull String> iterable;
+
+		private IterableHolder(Iterable<String> iterable) {
+			this.iterable = iterable;
+		}
+	}
+
+	private static class IterableImpl<T> implements Iterable<T> {
+
+		private final List<T> innerList;
+
+		private IterableImpl(List<T> innerList) {
+			this.innerList = innerList;
+		}
+
+		@Override
+		public Iterator<T> iterator() {
+			return innerList.iterator();
+		}
+	}
+}

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/builtin/JavaFXValueExtractorsTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/builtin/JavaFXValueExtractorsTest.java
@@ -1,0 +1,274 @@
+/**
+ * Bean Validation TCK
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.beanvalidation.tck.tests.valueextraction.builtin;
+
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationWith;
+
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validator;
+import javax.validation.constraints.AssertTrue;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import javax.validation.valueextraction.ValueExtractor;
+
+import org.hibernate.beanvalidation.tck.beanvalidation.Sections;
+import org.hibernate.beanvalidation.tck.tests.AbstractTCKTest;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.ListProperty;
+import javafx.beans.property.MapProperty;
+import javafx.beans.property.ReadOnlyBooleanProperty;
+import javafx.beans.property.ReadOnlyDoubleWrapper;
+import javafx.beans.property.ReadOnlyListWrapper;
+import javafx.beans.property.ReadOnlyMapWrapper;
+import javafx.beans.property.ReadOnlySetWrapper;
+import javafx.beans.property.SetProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.collections.ObservableMap;
+import javafx.collections.ObservableSet;
+
+/**
+ * Tests for JavaFX {@link ValueExtractor}s.
+ *
+ * @author Khalid Alqinyah
+ * @author Hardy Ferentschik
+ * @author Guillaume Smet
+ */
+@SuppressWarnings("restriction")
+@SpecVersion(spec = "beanvalidation", version = "2.0.0")
+public class JavaFXValueExtractorsTest extends AbstractTCKTest {
+
+	@Deployment
+	public static WebArchive createTestArchive() {
+		return webArchiveBuilder()
+				.withTestClass( JavaFXValueExtractorsTest.class )
+				.build();
+	}
+
+	@Test
+	@SpecAssertion(section = Sections.VALUEEXTRACTORDEFINITION_BUILTINVALUEEXTRACTORS, id = "f")
+	public void testJavaFXBasicProperties() {
+		Set<ConstraintViolation<BasicPropertiesEntity>> constraintViolations = getValidator().validate( new BasicPropertiesEntity() );
+
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationWith()
+						.constraintType( NotNull.class )
+						.propertyPath( pathWith().property( "stringProperty" ) ),
+				violationWith()
+						.constraintType( Max.class )
+						.propertyPath( pathWith().property( "doubleProperty" ) ),
+				violationWith()
+						.constraintType( Min.class )
+						.propertyPath( pathWith().property( "integerProperty" ) ),
+				violationWith()
+						.constraintType( AssertTrue.class )
+						.propertyPath( pathWith().property( "booleanProperty" ) )
+		);
+	}
+
+	@Test
+	@SpecAssertion(section = Sections.VALUEEXTRACTORDEFINITION_BUILTINVALUEEXTRACTORS, id = "g")
+	public void testValueExtractionForPropertyList() {
+		Validator validator = getValidator();
+
+		Set<ConstraintViolation<ListPropertyEntity>> constraintViolations = validator.validate( ListPropertyEntity.valid() );
+		assertNumberOfViolations( constraintViolations, 0 );
+
+		constraintViolations = validator.validate( ListPropertyEntity.invalidList() );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationWith()
+						.constraintType( Size.class )
+						.propertyPath( pathWith().property( "listProperty" ) )
+		);
+
+		constraintViolations = validator.validate( ListPropertyEntity.invalidListElement() );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationWith()
+						.constraintType( Size.class )
+						.propertyPath( pathWith()
+								.property( "listProperty" )
+								.containerElement( "<list element>", true, null, 0, ListProperty.class, 0 ) )
+		);
+	}
+
+	@Test
+	@SpecAssertion(section = Sections.VALUEEXTRACTORDEFINITION_BUILTINVALUEEXTRACTORS, id = "h")
+	public void testValueExtractionForPropertySet() {
+		Validator validator = getValidator();
+
+		Set<ConstraintViolation<SetPropertyEntity>> constraintViolations = validator.validate( SetPropertyEntity.valid() );
+		assertNumberOfViolations( constraintViolations, 0 );
+
+		constraintViolations = validator.validate( SetPropertyEntity.invalidSet() );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationWith()
+						.constraintType( Size.class )
+						.propertyPath( pathWith().property( "setProperty" ) )
+		);
+
+		constraintViolations = validator.validate( SetPropertyEntity.invalidSetElement() );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationWith()
+						.constraintType( Size.class )
+						.propertyPath( pathWith()
+								.property( "setProperty" )
+								.containerElement( "<iterable element>", true, null, null, SetProperty.class, 0 ) )
+		);
+	}
+
+	@Test
+	@SpecAssertion(section = Sections.VALUEEXTRACTORDEFINITION_BUILTINVALUEEXTRACTORS, id = "i")
+	public void testValueExtractionForPropertyMap() {
+		Validator validator = getValidator();
+
+		Set<ConstraintViolation<MapPropertyEntity>> constraintViolations = validator.validate( MapPropertyEntity.valid() );
+		assertNumberOfViolations( constraintViolations, 0 );
+
+		constraintViolations = validator.validate( MapPropertyEntity.invalidMap() );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationWith()
+						.constraintType( Size.class )
+						.propertyPath( pathWith().property( "mapProperty" ) )
+		);
+
+		constraintViolations = validator.validate( MapPropertyEntity.invalidMapKey() );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationWith()
+						.constraintType( Size.class )
+						.propertyPath( pathWith()
+								.property( "mapProperty" )
+								.containerElement( "<map key>", true, "app", null, MapProperty.class, 0 ) )
+		);
+
+		constraintViolations = validator.validate( MapPropertyEntity.invalidMapValue() );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationWith()
+						.constraintType( NotBlank.class )
+						.propertyPath( pathWith()
+								.property( "mapProperty" )
+								.containerElement( "<map value>", true, "pear", null, MapProperty.class, 1 ) )
+		);
+	}
+
+	public class BasicPropertiesEntity {
+
+		@NotNull
+		private StringProperty stringProperty = new SimpleStringProperty( null );
+
+		@Max(value = 3)
+		private ReadOnlyDoubleWrapper doubleProperty = new ReadOnlyDoubleWrapper( 4.5 );
+
+		@Min(value = 3)
+		private IntegerProperty integerProperty = new SimpleIntegerProperty( 2 );
+
+		@AssertTrue
+		private ReadOnlyBooleanProperty booleanProperty = new SimpleBooleanProperty( false );
+	}
+
+	public static class ListPropertyEntity {
+
+		@Size(min = 3)
+		private ListProperty<@Size(min = 4) String> listProperty;
+
+		private ListPropertyEntity(ObservableList<String> innerList) {
+			this.listProperty = new ReadOnlyListWrapper<String>( innerList );
+		}
+
+		public static ListPropertyEntity valid() {
+			return new ListPropertyEntity( FXCollections.observableArrayList( "apple", "pear", "cherry" ) );
+		}
+
+		public static ListPropertyEntity invalidList() {
+			return new ListPropertyEntity( FXCollections.observableArrayList( "apple" ) );
+		}
+
+		public static ListPropertyEntity invalidListElement() {
+			return new ListPropertyEntity( FXCollections.observableArrayList( "app", "pear", "cherry" ) );
+		}
+	}
+
+	public static class SetPropertyEntity {
+
+		@Size(min = 3)
+		private SetProperty<@Size(min = 4) String> setProperty;
+
+		private SetPropertyEntity(ObservableSet<String> innerList) {
+			this.setProperty = new ReadOnlySetWrapper<String>( innerList );
+		}
+
+		public static SetPropertyEntity valid() {
+			return new SetPropertyEntity( FXCollections.observableSet( "apple", "pear", "cherry" ) );
+		}
+
+		public static SetPropertyEntity invalidSet() {
+			return new SetPropertyEntity( FXCollections.observableSet( "apple" ) );
+		}
+
+		public static SetPropertyEntity invalidSetElement() {
+			return new SetPropertyEntity( FXCollections.observableSet( "app", "pear", "cherry" ) );
+		}
+	}
+
+	public static class MapPropertyEntity {
+
+		@Size(min = 3)
+		private MapProperty<@Size(min = 4) String, @NotBlank String> mapProperty = new ReadOnlyMapWrapper<String, String>();
+
+		private MapPropertyEntity(ObservableMap<String, String> innerMap) {
+			this.mapProperty = new ReadOnlyMapWrapper<String, String>( innerMap );
+		}
+
+		public static MapPropertyEntity valid() {
+			ObservableMap<String, String> innerMap = FXCollections.observableHashMap();
+			innerMap.put( "apple", "apple@example.com" );
+			innerMap.put( "pear", "pear@example.com" );
+			innerMap.put( "cherry", "cherry@example.com" );
+
+			return new MapPropertyEntity( innerMap );
+		}
+
+		public static MapPropertyEntity invalidMap() {
+			return new MapPropertyEntity( FXCollections.observableHashMap() );
+		}
+
+		public static MapPropertyEntity invalidMapKey() {
+			ObservableMap<String, String> innerMap = FXCollections.observableHashMap();
+			innerMap.put( "app", "apple@example.com" );
+			innerMap.put( "pear", "pear@example.com" );
+			innerMap.put( "cherry", "cherry@example.com" );
+
+			return new MapPropertyEntity( innerMap );
+		}
+
+		public static MapPropertyEntity invalidMapValue() {
+			ObservableMap<String, String> innerMap = FXCollections.observableHashMap();
+			innerMap.put( "apple", "apple@example.com" );
+			innerMap.put( "pear", " " );
+			innerMap.put( "cherry", "cherry@example.com" );
+
+			return new MapPropertyEntity( innerMap );
+		}
+	}
+}

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/builtin/ListValueExtractorTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/builtin/ListValueExtractorTest.java
@@ -1,0 +1,64 @@
+/**
+ * Bean Validation TCK
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.beanvalidation.tck.tests.valueextraction.builtin;
+
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validator;
+import javax.validation.constraints.NotNull;
+
+import org.hibernate.beanvalidation.tck.beanvalidation.Sections;
+import org.hibernate.beanvalidation.tck.tests.AbstractTCKTest;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
+/**
+ * @author Guillaume Smet
+ */
+@SpecVersion(spec = "beanvalidation", version = "2.0.0")
+public class ListValueExtractorTest extends AbstractTCKTest {
+
+	@Deployment
+	public static WebArchive createTestArchive() {
+		return webArchiveBuilder()
+				.withTestClass( ListValueExtractorTest.class )
+				.build();
+	}
+
+	@Test
+	@SpecAssertion(section = Sections.VALUEEXTRACTORDEFINITION_BUILTINVALUEEXTRACTORS, id = "b")
+	public void listValueExtractor() {
+		Validator validator = getValidator();
+
+		Set<ConstraintViolation<ListHolder>> violations = validator.validate( new ListHolder( Arrays.asList( "valid", null ) ) );
+
+		assertThat( violations ).containsOnlyPaths(
+				pathWith()
+						.property( "list" )
+						.containerElement( "<list element>", true, null, 1, List.class, 0 )
+		);
+	}
+
+	private static class ListHolder {
+
+		@SuppressWarnings("unused")
+		private final List<@NotNull String> list;
+
+		private ListHolder(List<String> list) {
+			this.list = list;
+		}
+	}
+}

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/builtin/MapValueExtractorTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/builtin/MapValueExtractorTest.java
@@ -1,0 +1,72 @@
+/**
+ * Bean Validation TCK
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.beanvalidation.tck.tests.valueextraction.builtin;
+
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validator;
+import javax.validation.constraints.NotNull;
+
+import org.hibernate.beanvalidation.tck.beanvalidation.Sections;
+import org.hibernate.beanvalidation.tck.tests.AbstractTCKTest;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
+/**
+ * @author Guillaume Smet
+ */
+@SpecVersion(spec = "beanvalidation", version = "2.0.0")
+public class MapValueExtractorTest extends AbstractTCKTest {
+
+	@Deployment
+	public static WebArchive createTestArchive() {
+		return webArchiveBuilder()
+				.withTestClass( MapValueExtractorTest.class )
+				.build();
+	}
+
+	@Test
+	@SpecAssertion(section = Sections.VALUEEXTRACTORDEFINITION_BUILTINVALUEEXTRACTORS, id = "c")
+	public void mapValueExtractor() {
+		Validator validator = getValidator();
+
+		Map<String, String> map = new HashMap<>();
+		map.put( "valid1", "valid2" );
+		map.put( null, "valid3" );
+		map.put( "valid4", null );
+
+		Set<ConstraintViolation<MapHolder>> violations = validator.validate( new MapHolder( map ) );
+
+		assertThat( violations ).containsOnlyPaths(
+				pathWith()
+						.property( "map" )
+						.containerElement( "<map value>", true, "valid4", null, Map.class, 1 ),
+				pathWith()
+						.property( "map" )
+						.containerElement( "<map key>", true, null, null, Map.class, 0 )
+		);
+	}
+
+	private static class MapHolder {
+
+		@SuppressWarnings("unused")
+		private final Map<@NotNull String, @NotNull String> map;
+
+		private MapHolder(Map<String, String> map) {
+			this.map = map;
+		}
+	}
+}

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/builtin/OptionalValueExtractorTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/builtin/OptionalValueExtractorTest.java
@@ -1,0 +1,132 @@
+/**
+ * Bean Validation TCK
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.beanvalidation.tck.tests.valueextraction.builtin;
+
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validator;
+import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+import org.hibernate.beanvalidation.tck.beanvalidation.Sections;
+import org.hibernate.beanvalidation.tck.tests.AbstractTCKTest;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
+/**
+ * @author Guillaume Smet
+ */
+@SpecVersion(spec = "beanvalidation", version = "2.0.0")
+public class OptionalValueExtractorTest extends AbstractTCKTest {
+
+	@Deployment
+	public static WebArchive createTestArchive() {
+		return webArchiveBuilder()
+				.withTestClass( OptionalValueExtractorTest.class )
+				.build();
+	}
+
+	@Test
+	@SpecAssertion(section = Sections.VALUEEXTRACTORDEFINITION_BUILTINVALUEEXTRACTORS, id = "d")
+	public void optionalValueExtractor() {
+		Validator validator = getValidator();
+
+		Set<ConstraintViolation<OptionalHolder>> violations = validator.validate( new OptionalHolder( Optional.empty() ) );
+
+		assertThat( violations ).containsOnlyPaths(
+				pathWith().property( "optional" )
+		);
+	}
+
+	@Test
+	@SpecAssertion(section = Sections.VALUEEXTRACTORDEFINITION_BUILTINVALUEEXTRACTORS, id = "e")
+	public void optionalIntValueExtractor() {
+		Validator validator = getValidator();
+
+		Set<ConstraintViolation<OptionalIntHolder>> violations = validator.validate( new OptionalIntHolder( OptionalInt.of( 3 ) ) );
+
+		assertThat( violations ).containsOnlyPaths(
+				pathWith().property( "optionalInt" )
+		);
+	}
+
+	@Test
+	@SpecAssertion(section = Sections.VALUEEXTRACTORDEFINITION_BUILTINVALUEEXTRACTORS, id = "e")
+	public void optionalLongValueExtractor() {
+		Validator validator = getValidator();
+
+		Set<ConstraintViolation<OptionalLongHolder>> violations = validator.validate( new OptionalLongHolder( OptionalLong.of( 3 ) ) );
+
+		assertThat( violations ).containsOnlyPaths(
+				pathWith().property( "optionalLong" )
+		);
+	}
+
+	@Test
+	@SpecAssertion(section = Sections.VALUEEXTRACTORDEFINITION_BUILTINVALUEEXTRACTORS, id = "e")
+	public void optionalDoubleValueExtractor() {
+		Validator validator = getValidator();
+
+		Set<ConstraintViolation<OptionalDoubleHolder>> violations = validator.validate( new OptionalDoubleHolder( OptionalDouble.of( 3 ) ) );
+
+		assertThat( violations ).containsOnlyPaths(
+				pathWith().property( "optionalDouble" )
+		);
+	}
+
+	private static class OptionalHolder {
+
+		@SuppressWarnings("unused")
+		private final Optional<@NotNull String> optional;
+
+		private OptionalHolder(Optional<String> optional) {
+			this.optional = optional;
+		}
+	}
+
+	private static class OptionalIntHolder {
+
+		@Min(5)
+		private final OptionalInt optionalInt;
+
+		private OptionalIntHolder(OptionalInt optionalInt) {
+			this.optionalInt = optionalInt;
+		}
+	}
+
+	private static class OptionalLongHolder {
+
+		@Min(5)
+		private final OptionalLong optionalLong;
+
+		private OptionalLongHolder(OptionalLong optionalLong) {
+			this.optionalLong = optionalLong;
+		}
+	}
+
+	private static class OptionalDoubleHolder {
+
+		@DecimalMin("5")
+		private final OptionalDouble optionalDouble;
+
+		private OptionalDoubleHolder(OptionalDouble optionalDouble) {
+			this.optionalDouble = optionalDouble;
+		}
+	}
+}

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/definition/InvalidValueExtractorTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/definition/InvalidValueExtractorTest.java
@@ -1,0 +1,78 @@
+/**
+ * Bean Validation TCK
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.beanvalidation.tck.tests.valueextraction.definition;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.validation.Validation;
+import javax.validation.valueextraction.ExtractedValue;
+import javax.validation.valueextraction.ValueExtractor;
+import javax.validation.valueextraction.ValueExtractorDefinitionException;
+
+import org.hibernate.beanvalidation.tck.beanvalidation.Sections;
+import org.hibernate.beanvalidation.tck.tests.AbstractTCKTest;
+import org.hibernate.beanvalidation.tck.tests.valueextraction.definition.model.Container;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
+/**
+ * Test the exceptions thrown in case of an invalid {@link ValueExtractor}.
+ *
+ * @author Guillaume Smet
+ */
+@SpecVersion(spec = "beanvalidation", version = "2.0.0")
+public class InvalidValueExtractorTest extends AbstractTCKTest {
+
+	@Deployment
+	public static WebArchive createTestArchive() {
+		return webArchiveBuilder()
+				.withTestClass( InvalidValueExtractorTest.class )
+				.withPackage( Container.class.getPackage() )
+				.build();
+	}
+
+	@Test(expectedExceptions = ValueExtractorDefinitionException.class)
+	@SpecAssertion(section = Sections.VALUEEXTRACTORDEFINITION_EXTRACTEDVALUE, id = "a")
+	@SpecAssertion(section = Sections.VALUEEXTRACTORDEFINITION_EXTRACTEDVALUE, id = "d")
+	@SpecAssertion(section = Sections.VALUEEXTRACTORDEFINITION_EXAMPLES, id = "a")
+	public void severalExtractedValuesThrowException() {
+		Validation.byDefaultProvider().configure()
+				.addValueExtractor( new SeveralExtractedValuesValueExtractor() )
+				.buildValidatorFactory()
+				.getValidator();
+	}
+
+	@Test(expectedExceptions = ValueExtractorDefinitionException.class)
+	@SpecAssertion(section = Sections.VALUEEXTRACTORDEFINITION_EXTRACTEDVALUE, id = "a")
+	@SpecAssertion(section = Sections.VALUEEXTRACTORDEFINITION_EXTRACTEDVALUE, id = "d")
+	public void noExtractedValueThrowsException() {
+		Validation.byDefaultProvider().configure()
+				.addValueExtractor( new NoExtractedValueValueExtractor() )
+				.buildValidatorFactory()
+				.getValidator();
+	}
+
+	private class SeveralExtractedValuesValueExtractor implements ValueExtractor<Map<@ExtractedValue ?, @ExtractedValue ?>> {
+
+		@Override
+		public void extractValues(Map<?, ?> originalValue, ValueReceiver receiver) {
+			throw new IllegalStateException( "May not be called" );
+		}
+	}
+
+	private class NoExtractedValueValueExtractor implements ValueExtractor<List<?>> {
+
+		@Override
+		public void extractValues(List<?> originalValue, ValueReceiver receiver) {
+			throw new IllegalStateException( "May not be called" );
+		}
+	}
+}

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/definition/ValueExtractorDefinitionTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/definition/ValueExtractorDefinitionTest.java
@@ -1,0 +1,254 @@
+/**
+ * Bean Validation TCK
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.beanvalidation.tck.tests.valueextraction.definition;
+
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationWith;
+import static org.testng.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Valid;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.constraints.NotNull;
+
+import org.hibernate.beanvalidation.tck.beanvalidation.Sections;
+import org.hibernate.beanvalidation.tck.tests.AbstractTCKTest;
+import org.hibernate.beanvalidation.tck.tests.valueextraction.definition.model.Container;
+import org.hibernate.beanvalidation.tck.tests.valueextraction.definition.model.ContainerElement;
+import org.hibernate.beanvalidation.tck.tests.valueextraction.definition.model.ContainerValueExtractor;
+import org.hibernate.beanvalidation.tck.tests.valueextraction.definition.model.CustomConstraint;
+import org.hibernate.beanvalidation.tck.tests.valueextraction.definition.model.IndexedValueContainerValueExtractor;
+import org.hibernate.beanvalidation.tck.tests.valueextraction.definition.model.IterableValueContainerValueExtractor;
+import org.hibernate.beanvalidation.tck.tests.valueextraction.definition.model.KeyedValueContainerValueExtractor;
+import org.hibernate.beanvalidation.tck.tests.valueextraction.definition.model.LocalMapKeyExtractor;
+import org.hibernate.beanvalidation.tck.tests.valueextraction.definition.model.LocalMapValueExtractor;
+import org.hibernate.beanvalidation.tck.tests.valueextraction.definition.model.NullNodeNameContainerValueExtractor;
+import org.hibernate.beanvalidation.tck.tests.valueextraction.definition.model.Order;
+import org.hibernate.beanvalidation.tck.tests.valueextraction.definition.model.RetailOrder;
+import org.hibernate.beanvalidation.tck.tests.valueextraction.definition.model.ValueContainerValueExtractor;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
+/**
+ * @author Guillaume Smet
+ */
+@SpecVersion(spec = "beanvalidation", version = "2.0.0")
+public class ValueExtractorDefinitionTest extends AbstractTCKTest {
+
+	@Deployment
+	public static WebArchive createTestArchive() {
+		return webArchiveBuilder()
+				.withTestClass( ValueExtractorDefinitionTest.class )
+				.withPackage( Container.class.getPackage() )
+				.build();
+	}
+
+	@Test
+	@SpecAssertion(section = Sections.VALUEEXTRACTORDEFINITION, id = "a")
+	public void instanceAndValueReceiverPassedToExtractValues() {
+		Container<String> container = new Container<String>( null );
+		StringContainerHolder containerHolder = new StringContainerHolder( container );
+
+		Validator validator = Validation.byDefaultProvider().configure()
+				.addValueExtractor( new ContainerValueExtractor( container ) )
+				.buildValidatorFactory()
+				.getValidator();
+
+		validator.validate( containerHolder );
+
+		assertEquals( ContainerValueExtractor.callCounter, 1 );
+	}
+
+	@Test
+	@SpecAssertion(section = Sections.VALUEEXTRACTORDEFINITION, id = "b")
+	@SpecAssertion(section = Sections.VALUEEXTRACTORDEFINITION, id = "f")
+	public void value() {
+		Container<ContainerElement> container = new Container<ContainerElement>( CustomConstraint.INSTANCE );
+		ContainerHolder containerHolder = new ContainerHolder( container );
+
+		Validator validator = Validation.byDefaultProvider().configure()
+				.addValueExtractor( new ValueContainerValueExtractor() )
+				.buildValidatorFactory()
+				.getValidator();
+
+		Set<ConstraintViolation<ContainerHolder>> violations = validator.validate( containerHolder );
+
+		assertThat( violations ).containsOnlyPaths(
+				pathWith()
+						.property( "container" )
+						.containerElement( "<node name>", false, null, null, Container.class, 0 )
+		);
+	}
+
+	@Test
+	@SpecAssertion(section = Sections.VALUEEXTRACTORDEFINITION, id = "c")
+	@SpecAssertion(section = Sections.VALUEEXTRACTORDEFINITION, id = "f")
+	public void iterableValue() {
+		Container<ContainerElement> container = new Container<ContainerElement>( CustomConstraint.INSTANCE );
+		ContainerHolder containerHolder = new ContainerHolder( container );
+
+		Validator validator = Validation.byDefaultProvider().configure()
+				.addValueExtractor( new IterableValueContainerValueExtractor() )
+				.buildValidatorFactory()
+				.getValidator();
+
+		Set<ConstraintViolation<ContainerHolder>> violations = validator.validate( containerHolder );
+
+		assertThat( violations ).containsOnlyPaths(
+				pathWith()
+						.property( "container" )
+						.containerElement( "<node name>", true, null, null, Container.class, 0 )
+		);
+	}
+
+	@Test
+	@SpecAssertion(section = Sections.VALUEEXTRACTORDEFINITION, id = "d")
+	@SpecAssertion(section = Sections.VALUEEXTRACTORDEFINITION, id = "f")
+	public void indexedValue() {
+		Container<ContainerElement> container = new Container<ContainerElement>( CustomConstraint.INSTANCE );
+		ContainerHolder containerHolder = new ContainerHolder( container );
+
+		Validator validator = Validation.byDefaultProvider().configure()
+				.addValueExtractor( new IndexedValueContainerValueExtractor() )
+				.buildValidatorFactory()
+				.getValidator();
+
+		Set<ConstraintViolation<ContainerHolder>> violations = validator.validate( containerHolder );
+
+		assertThat( violations ).containsOnlyPaths(
+				pathWith()
+						.property( "container" )
+						.containerElement( "<node name>", true, null, 13, Container.class, 0 )
+		);
+	}
+
+	@Test
+	@SpecAssertion(section = Sections.VALUEEXTRACTORDEFINITION, id = "e")
+	@SpecAssertion(section = Sections.VALUEEXTRACTORDEFINITION, id = "f")
+	public void keyedValue() {
+		Container<ContainerElement> container = new Container<ContainerElement>( CustomConstraint.INSTANCE );
+		ContainerHolder containerHolder = new ContainerHolder( container );
+
+		Validator validator = Validation.byDefaultProvider().configure()
+				.addValueExtractor( new KeyedValueContainerValueExtractor() )
+				.buildValidatorFactory()
+				.getValidator();
+
+		Set<ConstraintViolation<ContainerHolder>> violations = validator.validate( containerHolder );
+
+		assertThat( violations ).containsOnlyPaths(
+				pathWith()
+						.property( "container" )
+						.containerElement( "<node name>", true, "key", null, Container.class, 0 )
+		);
+	}
+
+	@Test
+	@SpecAssertion(section = Sections.VALUEEXTRACTORDEFINITION, id = "g")
+	public void nullNodeName() {
+		Container<ContainerElement> container = new Container<ContainerElement>( CustomConstraint.INSTANCE );
+		ContainerHolder containerHolder = new ContainerHolder( container );
+
+		Validator validator = Validation.byDefaultProvider().configure()
+				.addValueExtractor( new NullNodeNameContainerValueExtractor() )
+				.buildValidatorFactory()
+				.getValidator();
+
+		Set<ConstraintViolation<ContainerHolder>> violations = validator.validate( containerHolder );
+
+		assertThat( violations ).containsOnlyPaths(
+				pathWith().property( "container" )
+		);
+	}
+
+	@Test
+	@SpecAssertion(section = Sections.VALUEEXTRACTORDEFINITION, id = "h")
+	@SpecAssertion(section = Sections.VALUEEXTRACTORDEFINITION, id = "i")
+	public void valuePassedToExtractorRetrievedFromHost() {
+		Map<String, Order> propertyMap = new HashMap<>();
+		propertyMap.put( "name1", new Order( "INVALID-ID" ) );
+		propertyMap.put( "name2", new Order( null ) );
+		propertyMap.put( null, new Order( "RETAIL-1" ) );
+
+		Map<String, Order> getterMap = new HashMap<>();
+		getterMap.put( null, new Order( "RETAIL-2" ) );
+		getterMap.put( "name2", new Order( "INVALID-ID" ) );
+
+		MapHolder mapHolder = new MapHolder( propertyMap, getterMap );
+
+		Validator validator = Validation.byDefaultProvider().configure()
+				.addValueExtractor( new LocalMapValueExtractor( propertyMap ) )
+				.addValueExtractor( new LocalMapKeyExtractor( getterMap ) )
+				.buildValidatorFactory()
+				.getValidator();
+
+		Set<ConstraintViolation<MapHolder>> violations = validator.validate( mapHolder );
+		assertThat( violations ).containsOnlyViolations(
+				violationWith()
+						.constraintType( RetailOrder.class )
+						.propertyPath( pathWith()
+								.property( "ordersByName" )
+								.containerElement( "<map value>", true, "name1", null, Map.class, 1 ) ),
+				violationWith()
+						.constraintType( NotNull.class )
+						.propertyPath( pathWith()
+								.property( "ordersByName" )
+								.property( "id", true, "name2", null, Map.class, 1 ) ),
+				violationWith()
+						.constraintType( NotNull.class )
+						.propertyPath( pathWith()
+								.property( "ordersByName" )
+								.containerElement( "<map key>", true, null, null, Map.class, 0 ) )
+		);
+	}
+
+	private static class StringContainerHolder {
+
+		@SuppressWarnings("unused")
+		private final Container<@NotNull String> container;
+
+		private StringContainerHolder(Container<String> container) {
+			this.container = container;
+		}
+	}
+
+	private static class ContainerHolder {
+
+		@SuppressWarnings("unused")
+		private final Container<@CustomConstraint ContainerElement> container;
+
+		private ContainerHolder(Container<ContainerElement> container) {
+			this.container = container;
+		}
+	}
+
+	@SuppressWarnings("unused")
+	private static class MapHolder {
+
+		private final Map<String, @Valid @RetailOrder Order> ordersByName;
+
+		private final Map<String, Order> getterMap;
+
+		private MapHolder(Map<String, Order> propertyMap, Map<String, Order> getterMap) {
+			this.ordersByName = propertyMap;
+			this.getterMap = getterMap;
+		}
+
+		public Map<@NotNull String, Order> getOrdersByName() {
+			return getterMap;
+		}
+	}
+}

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/definition/model/Container.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/definition/model/Container.java
@@ -1,0 +1,20 @@
+/**
+ * Bean Validation TCK
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.beanvalidation.tck.tests.valueextraction.definition.model;
+
+public class Container<T> {
+
+	private final T element;
+
+	public Container(T element) {
+		this.element = element;
+	}
+
+	public T getElement() {
+		return element;
+	}
+}

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/definition/model/ContainerElement.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/definition/model/ContainerElement.java
@@ -1,0 +1,11 @@
+/**
+ * Bean Validation TCK
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.beanvalidation.tck.tests.valueextraction.definition.model;
+
+
+public class ContainerElement {
+}

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/definition/model/ContainerValueExtractor.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/definition/model/ContainerValueExtractor.java
@@ -1,0 +1,34 @@
+/**
+ * Bean Validation TCK
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.beanvalidation.tck.tests.valueextraction.definition.model;
+
+import javax.validation.valueextraction.ExtractedValue;
+import javax.validation.valueextraction.ValueExtractor;
+
+public class ContainerValueExtractor implements ValueExtractor<Container<@ExtractedValue ?>> {
+
+	public static int callCounter = 0;
+
+	private final Container<?> containerInstance;
+
+	public ContainerValueExtractor(Container<?> containerInstance) {
+		this.containerInstance = containerInstance;
+	}
+
+	@Override
+	public void extractValues(Container<?> originalValue, ValueReceiver receiver) {
+		callCounter++;
+
+		if ( originalValue != containerInstance ) {
+			throw new IllegalArgumentException( "The instance passed to extractValues should be the same as the one registered in the construtor." );
+		}
+
+		if ( receiver == null ) {
+			throw new IllegalArgumentException( "The value receiver may not be null." );
+		}
+	}
+}

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/definition/model/CustomConstraint.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/definition/model/CustomConstraint.java
@@ -1,0 +1,47 @@
+/**
+ * Bean Validation TCK
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.beanvalidation.tck.tests.valueextraction.definition.model;
+
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.Payload;
+
+
+@Target(TYPE_USE)
+@Constraint(validatedBy = { CustomConstraint.Validator.class })
+@Documented
+@Retention(RUNTIME)
+public @interface CustomConstraint {
+
+	public static final ContainerElement INSTANCE = new ContainerElement();
+
+	String message() default "my custom constraint";
+
+	Class<?>[] groups() default { };
+
+	Class<? extends Payload>[] payload() default { };
+
+	public class Validator implements ConstraintValidator<CustomConstraint, ContainerElement> {
+
+		@Override
+		public boolean isValid(ContainerElement element, ConstraintValidatorContext constraintValidatorContext) {
+			if ( element != INSTANCE ) {
+				throw new IllegalArgumentException( "The passed element must be INSTANCE." );
+			}
+
+			return false;
+		}
+	}
+}

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/definition/model/IndexedValueContainerValueExtractor.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/definition/model/IndexedValueContainerValueExtractor.java
@@ -1,0 +1,18 @@
+/**
+ * Bean Validation TCK
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.beanvalidation.tck.tests.valueextraction.definition.model;
+
+import javax.validation.valueextraction.ExtractedValue;
+import javax.validation.valueextraction.ValueExtractor;
+
+public class IndexedValueContainerValueExtractor implements ValueExtractor<Container<@ExtractedValue ?>> {
+
+	@Override
+	public void extractValues(Container<?> originalValue, ValueReceiver receiver) {
+		receiver.indexedValue( "<node name>", 13, originalValue.getElement() );
+	}
+}

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/definition/model/IterableValueContainerValueExtractor.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/definition/model/IterableValueContainerValueExtractor.java
@@ -1,0 +1,18 @@
+/**
+ * Bean Validation TCK
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.beanvalidation.tck.tests.valueextraction.definition.model;
+
+import javax.validation.valueextraction.ExtractedValue;
+import javax.validation.valueextraction.ValueExtractor;
+
+public class IterableValueContainerValueExtractor implements ValueExtractor<Container<@ExtractedValue ?>> {
+
+	@Override
+	public void extractValues(Container<?> originalValue, ValueReceiver receiver) {
+		receiver.iterableValue( "<node name>", originalValue.getElement() );
+	}
+}

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/definition/model/KeyedValueContainerValueExtractor.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/definition/model/KeyedValueContainerValueExtractor.java
@@ -1,0 +1,18 @@
+/**
+ * Bean Validation TCK
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.beanvalidation.tck.tests.valueextraction.definition.model;
+
+import javax.validation.valueextraction.ExtractedValue;
+import javax.validation.valueextraction.ValueExtractor;
+
+public class KeyedValueContainerValueExtractor implements ValueExtractor<Container<@ExtractedValue ?>> {
+
+	@Override
+	public void extractValues(Container<?> originalValue, ValueReceiver receiver) {
+		receiver.keyedValue( "<node name>", "key", originalValue.getElement() );
+	}
+}

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/definition/model/LocalMapKeyExtractor.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/definition/model/LocalMapKeyExtractor.java
@@ -1,0 +1,32 @@
+/**
+ * Bean Validation TCK
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.beanvalidation.tck.tests.valueextraction.definition.model;
+
+import java.util.Map;
+
+import javax.validation.valueextraction.ExtractedValue;
+import javax.validation.valueextraction.ValueExtractor;
+
+public class LocalMapKeyExtractor implements ValueExtractor<Map<@ExtractedValue ?, ?>> {
+
+	private final Map<?, ?> instance;
+
+	public LocalMapKeyExtractor(Map<?, ?> instance) {
+		this.instance = instance;
+	}
+
+	@Override
+	public void extractValues(Map<?, ?> originalValue, ValueReceiver receiver) {
+		if (originalValue != instance) {
+			throw new IllegalArgumentException( "The instance passed to extractValues should be the same as the one registered in the constructor." );
+		}
+
+		for ( Map.Entry<?, ?> entry : originalValue.entrySet() ) {
+			receiver.keyedValue( "<map key>", entry.getKey(), entry.getKey() );
+		}
+	}
+}

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/definition/model/LocalMapValueExtractor.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/definition/model/LocalMapValueExtractor.java
@@ -1,0 +1,32 @@
+/**
+ * Bean Validation TCK
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.beanvalidation.tck.tests.valueextraction.definition.model;
+
+import java.util.Map;
+
+import javax.validation.valueextraction.ExtractedValue;
+import javax.validation.valueextraction.ValueExtractor;
+
+public class LocalMapValueExtractor implements ValueExtractor<Map<?, @ExtractedValue ?>> {
+
+	private final Map<?, ?> instance;
+
+	public LocalMapValueExtractor(Map<?, ?> instance) {
+		this.instance = instance;
+	}
+
+	@Override
+	public void extractValues(Map<?, ?> originalValue, ValueReceiver receiver) {
+		if (originalValue != instance) {
+			throw new IllegalArgumentException( "The instance passed to extractValues should be the same as the one registered in the constructor." );
+		}
+
+		for ( Map.Entry<?, ?> entry : originalValue.entrySet() ) {
+			receiver.keyedValue( "<map value>", entry.getKey(), entry.getValue() );
+		}
+	}
+}

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/definition/model/NullNodeNameContainerValueExtractor.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/definition/model/NullNodeNameContainerValueExtractor.java
@@ -1,0 +1,18 @@
+/**
+ * Bean Validation TCK
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.beanvalidation.tck.tests.valueextraction.definition.model;
+
+import javax.validation.valueextraction.ExtractedValue;
+import javax.validation.valueextraction.ValueExtractor;
+
+public class NullNodeNameContainerValueExtractor implements ValueExtractor<Container<@ExtractedValue ?>> {
+
+	@Override
+	public void extractValues(Container<?> originalValue, ValueReceiver receiver) {
+		receiver.value( null, originalValue.getElement() );
+	}
+}

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/definition/model/Order.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/definition/model/Order.java
@@ -1,0 +1,23 @@
+/**
+ * Bean Validation TCK
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.beanvalidation.tck.tests.valueextraction.definition.model;
+
+import javax.validation.constraints.NotNull;
+
+public class Order {
+
+	@NotNull
+	private final String id;
+
+	public Order(String id) {
+		this.id = id;
+	}
+
+	public String getId() {
+		return id;
+	}
+}

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/definition/model/RetailOrder.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/definition/model/RetailOrder.java
@@ -1,0 +1,45 @@
+/**
+ * Bean Validation TCK
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.beanvalidation.tck.tests.valueextraction.definition.model;
+
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.Payload;
+
+
+@Target(TYPE_USE)
+@Constraint(validatedBy = { RetailOrder.Validator.class })
+@Documented
+@Retention(RUNTIME)
+public @interface RetailOrder {
+
+	String message() default "not a valid retail order";
+
+	Class<?>[] groups() default { };
+
+	Class<? extends Payload>[] payload() default { };
+
+	public class Validator implements ConstraintValidator<RetailOrder, Order> {
+
+		@Override
+		public boolean isValid(Order order, ConstraintValidatorContext constraintValidatorContext) {
+			if ( order == null || order.getId() == null ) {
+				return true;
+			}
+
+			return order.getId().startsWith( "RETAIL-" );
+		}
+	}
+}

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/definition/model/ValueContainerValueExtractor.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/definition/model/ValueContainerValueExtractor.java
@@ -1,0 +1,18 @@
+/**
+ * Bean Validation TCK
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.beanvalidation.tck.tests.valueextraction.definition.model;
+
+import javax.validation.valueextraction.ExtractedValue;
+import javax.validation.valueextraction.ValueExtractor;
+
+public class ValueContainerValueExtractor implements ValueExtractor<Container<@ExtractedValue ?>> {
+
+	@Override
+	public void extractValues(Container<?> originalValue, ValueReceiver receiver) {
+		receiver.value( "<node name>", originalValue.getElement() );
+	}
+}

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/util/ConstraintViolationAssert.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/util/ConstraintViolationAssert.java
@@ -232,10 +232,40 @@ public final class ConstraintViolationAssert {
 		return new PathExpectation();
 	}
 
+	public static ViolationExpectation violationWith() {
+		return new ViolationExpectation();
+	}
+
 	public static class ConstraintViolationSetAssert extends IterableAssert<ConstraintViolation<?>> {
 
 		protected ConstraintViolationSetAssert(Set<? extends ConstraintViolation<?>> actualViolations) {
 			super( actualViolations );
+		}
+
+		public void containsOnlyViolations(ViolationExpectation... expectedViolations) {
+			isNotNull();
+
+			List<ViolationExpectation> actualViolations = new ArrayList<>();
+
+			ViolationExpectationPropertiesToTest referencePropertiesToTest;
+			if ( expectedViolations.length == 0 ) {
+				referencePropertiesToTest = ViolationExpectationPropertiesToTest.all();
+			}
+			else {
+				referencePropertiesToTest = expectedViolations[0].propertiesToTest;
+				for ( ViolationExpectation expectedViolation : expectedViolations ) {
+					if ( !referencePropertiesToTest.equals( expectedViolation.propertiesToTest ) ) {
+						throw new IllegalArgumentException( String.format( "Expected violations passed in parameter must test the exact same properties but do not: %1$s != %2$s",
+								expectedViolations[0], expectedViolation ) );
+					}
+				}
+			}
+
+			for ( ConstraintViolation<?> violation : actual ) {
+				actualViolations.add( new ViolationExpectation( violation, referencePropertiesToTest ) );
+			}
+
+			Assertions.assertThat( actualViolations ).containsExactlyInAnyOrder( expectedViolations );
 		}
 
 		public void containsOnlyPaths(PathExpectation... paths) {
@@ -269,6 +299,274 @@ public final class ConstraintViolationAssert {
 			for ( PathExpectation pathExpectation : expectedPaths ) {
 				containsPath( pathExpectation );
 			}
+		}
+	}
+
+	public static class ViolationExpectation {
+
+		private final ViolationExpectationPropertiesToTest propertiesToTest = new ViolationExpectationPropertiesToTest();
+
+		private Class<? extends Annotation> constraintType;
+
+		private Class<?> rootBeanClass;
+
+		private String message;
+
+		private Object invalidValue;
+
+		private PathExpectation propertyPath;
+
+		public ViolationExpectation() {
+		}
+
+		public ViolationExpectation(ConstraintViolation<?> violation, ViolationExpectationPropertiesToTest propertiesToTest) {
+			if ( propertiesToTest.testConstraintType ) {
+				constraintType( violation.getConstraintDescriptor().getAnnotation().annotationType() );
+			}
+			if ( propertiesToTest.testRootBeanClass ) {
+				rootBeanClass( violation.getRootBeanClass() );
+			}
+			if ( propertiesToTest.testMessage ) {
+				message( violation.getMessage() );
+			}
+			if ( propertiesToTest.testInvalidValue ) {
+				invalidValue( violation.getInvalidValue() );
+			}
+			if ( propertiesToTest.testPropertyPath ) {
+				propertyPath( new PathExpectation( violation.getPropertyPath() ) );
+			}
+		}
+
+		public ViolationExpectation constraintType(Class<? extends Annotation> constraint) {
+			propertiesToTest.testConstraintType();
+			this.constraintType = constraint;
+			return this;
+		}
+
+		public ViolationExpectation rootBeanClass(Class<?> rootBeanClass) {
+			propertiesToTest.testRootBeanClass();
+			this.rootBeanClass = rootBeanClass;
+			return this;
+		}
+
+		public ViolationExpectation message(String message) {
+			propertiesToTest.testMessage();
+			this.message = message;
+			return this;
+		}
+
+		public ViolationExpectation invalidValue(Object invalidValue) {
+			propertiesToTest.testInvalidValue();
+			this.invalidValue = invalidValue;
+			return this;
+		}
+
+		public ViolationExpectation propertyPath(PathExpectation propertyPath) {
+			propertiesToTest.testPropertyPath();
+			this.propertyPath = propertyPath;
+			return this;
+		}
+
+		@Override
+		public String toString() {
+			String lineBreak = System.getProperty( "line.separator" );
+			StringBuilder asString = new StringBuilder( lineBreak + "ViolationExpectation(" + lineBreak );
+			if ( propertiesToTest.testConstraintType ) {
+				asString.append( "  constraintType: " ).append( constraintType ).append( lineBreak );
+			}
+			if ( propertiesToTest.testRootBeanClass ) {
+				asString.append( "  rootBeanClass: " ).append( rootBeanClass ).append( lineBreak );
+			}
+			if ( propertiesToTest.testMessage ) {
+				asString.append( "  message: " ).append( message ).append( lineBreak );
+			}
+			if ( propertiesToTest.testInvalidValue ) {
+				asString.append( "  invalidValue: " ).append( invalidValue ).append( lineBreak );
+			}
+			if ( propertiesToTest.testPropertyPath ) {
+				asString.append( "  propertyPath: " ).append( propertyPath.toStringInViolation() ).append( lineBreak );
+			}
+
+			return asString.append( ")" ).toString();
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			if ( propertiesToTest.testConstraintType ) {
+				result = prime * result + ( constraintType == null ? 0 : constraintType.hashCode() );
+			}
+			if ( propertiesToTest.testRootBeanClass ) {
+				result = prime * result + ( rootBeanClass == null ? 0 : rootBeanClass.hashCode() );
+			}
+			if ( propertiesToTest.testMessage ) {
+				result = prime * result + ( message == null ? 0 : message.hashCode() );
+			}
+			if ( propertiesToTest.testInvalidValue ) {
+				result = prime * result + ( invalidValue == null ? 0 : invalidValue.hashCode() );
+			}
+			if ( propertiesToTest.testPropertyPath ) {
+				result = prime * result + ( propertyPath == null ? 0 : propertyPath.hashCode() );
+			}
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if ( this == obj ) {
+				return true;
+			}
+			if ( obj == null ) {
+				return false;
+			}
+			if ( getClass() != obj.getClass() ) {
+				return false;
+			}
+			ViolationExpectation other = (ViolationExpectation) obj;
+			if ( propertiesToTest.testConstraintType ) {
+				if ( constraintType == null ) {
+					if ( other.constraintType != null ) {
+						return false;
+					}
+				}
+				else if ( !constraintType.equals( other.constraintType ) ) {
+					return false;
+				}
+			}
+			if ( propertiesToTest.testRootBeanClass ) {
+				if ( rootBeanClass == null ) {
+					if ( other.rootBeanClass != null ) {
+						return false;
+					}
+				}
+				else if ( !rootBeanClass.equals( other.rootBeanClass ) ) {
+					return false;
+				}
+			}
+			if ( propertiesToTest.testMessage ) {
+				if ( message == null ) {
+					if ( other.message != null ) {
+						return false;
+					}
+				}
+				else if ( !message.equals( other.message ) ) {
+					return false;
+				}
+			}
+			if ( propertiesToTest.testInvalidValue ) {
+				if ( invalidValue == null ) {
+					if ( other.invalidValue != null ) {
+						return false;
+					}
+				}
+				else if ( !invalidValue.equals( other.invalidValue ) ) {
+					return false;
+				}
+			}
+			if ( propertiesToTest.testPropertyPath ) {
+				if ( propertyPath == null ) {
+					if ( other.propertyPath != null ) {
+						return false;
+					}
+				}
+				else if ( !propertyPath.equals( other.propertyPath ) ) {
+					return false;
+				}
+			}
+			return true;
+		}
+	}
+
+	private static class ViolationExpectationPropertiesToTest {
+
+		private boolean testConstraintType = false;
+
+		private boolean testRootBeanClass = false;
+
+		private boolean testMessage = false;
+
+		private boolean testInvalidValue = false;
+
+		private boolean testPropertyPath = false;
+
+		private static ViolationExpectationPropertiesToTest all() {
+			ViolationExpectationPropertiesToTest propertiesToTest = new ViolationExpectationPropertiesToTest()
+					.testConstraintType()
+					.testRootBeanClass()
+					.testMessage()
+					.testInvalidValue()
+					.testPropertyPath();
+			return propertiesToTest;
+		}
+
+		private ViolationExpectationPropertiesToTest testConstraintType() {
+			testConstraintType = true;
+			return this;
+		}
+
+		private ViolationExpectationPropertiesToTest testRootBeanClass() {
+			testRootBeanClass = true;
+			return this;
+		}
+
+		private ViolationExpectationPropertiesToTest testMessage() {
+			testMessage = true;
+			return this;
+		}
+
+		private ViolationExpectationPropertiesToTest testInvalidValue() {
+			testInvalidValue = true;
+			return this;
+		}
+
+		private ViolationExpectationPropertiesToTest testPropertyPath() {
+			testPropertyPath = true;
+			return this;
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + ( testConstraintType ? 1 : 0 );
+			result = prime * result + ( testRootBeanClass ? 1 : 0 );
+			result = prime * result + ( testMessage ? 1 : 0 );
+			result = prime * result + ( testInvalidValue ? 1 : 0 );
+			result = prime * result + ( testPropertyPath ? 1 : 0 );
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if ( this == obj ) {
+				return true;
+			}
+			if ( obj == null ) {
+				return false;
+			}
+			if ( getClass() != obj.getClass() ) {
+				return false;
+			}
+
+			ViolationExpectationPropertiesToTest other = (ViolationExpectationPropertiesToTest) obj;
+			if ( testConstraintType != other.testConstraintType ) {
+				return false;
+			}
+			if ( testRootBeanClass != other.testRootBeanClass ) {
+				return false;
+			}
+			if ( testMessage != other.testMessage ) {
+				return false;
+			}
+			if ( testInvalidValue != other.testInvalidValue ) {
+				return false;
+			}
+			if ( testPropertyPath != other.testPropertyPath ) {
+				return false;
+			}
+
+			return true;
 		}
 	}
 
@@ -379,6 +677,16 @@ public final class ConstraintViolationAssert {
 			}
 
 			return asString.append( ")" ).toString();
+		}
+
+		public String toStringInViolation() {
+			String lineBreak = System.getProperty( "line.separator" );
+			StringBuilder asString = new StringBuilder( "PathExpectation(" + lineBreak );
+			for ( NodeExpectation node : nodes ) {
+				asString.append( "    " ).append( node ).append( lineBreak );
+			}
+
+			return asString.append( "  )" ).toString();
 		}
 
 		@Override


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/BVTCK-132
 * https://hibernate.atlassian.net/browse/BVTCK-133

This PR introduces the new testing utility we talked about the other day and uses it in some tests.

It also introduces most tests required to test the assertions of the paragraph Value extractor definition.

@gunnarmorling we have an issue with JavaFX and the incontainer mode: we need to make the JavaFX classes visible and apparently we would need something like that https://developer.jboss.org/thread/238426 . But then we would need to include a WildFly specific configuration file in the TCK (and other container will probably have issues to test that too). WDYT about it?