### PR TITLE
BVTCK-156 Improvements to the new containsOnlyViolations() testing API

### DIFF
--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/containerelement/ContainerElementConstraintListTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/containerelement/ContainerElementConstraintListTest.java
@@ -8,7 +8,7 @@ package org.hibernate.beanvalidation.tck.tests.constraints.containerelement;
 
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
@@ -56,21 +56,18 @@ public class ContainerElementConstraintListTest extends AbstractTCKTest {
 		Set<ConstraintViolation<TypeWithList1>> constraintViolations = getValidator().validate( l );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.property( "names" )
 								.containerElement( "<list element>", true, null, 1, List.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.property( "names" )
 								.containerElement( "<list element>", true, null, 2, List.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotNull.class )
-						.propertyPath( pathWith()
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
 								.property( "names" )
 								.containerElement( "<list element>", true, null, 2, List.class, 0 )
 						)
@@ -85,15 +82,13 @@ public class ContainerElementConstraintListTest extends AbstractTCKTest {
 		Set<ConstraintViolation<TypeWithList2>> constraintViolations = getValidator().validate( l );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.property( "names" )
 								.containerElement( "<list element>", true, null, 1, List.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.property( "names" )
 								.containerElement( "<list element>", true, null, 2, List.class, 0 )
 						)
@@ -104,11 +99,7 @@ public class ContainerElementConstraintListTest extends AbstractTCKTest {
 		constraintViolations = getValidator().validate( l );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( Size.class )
-						.propertyPath( pathWith()
-								.property( "names" )
-						)
+				violationOf(  Size.class  ).withProperty( "names" )
 		);
 	}
 
@@ -123,21 +114,18 @@ public class ContainerElementConstraintListTest extends AbstractTCKTest {
 		Set<ConstraintViolation<TypeWithList3>> constraintViolations = getValidator().validate( l );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.property( "strings" )
 								.containerElement( "<list element>", true, null, 0, List.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.property( "strings" )
 								.containerElement( "<list element>", true, null, 2, List.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotNull.class )
-						.propertyPath( pathWith()
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
 								.property( "strings" )
 								.containerElement( "<list element>", true, null, 2, List.class, 0 )
 						)
@@ -157,23 +145,20 @@ public class ContainerElementConstraintListTest extends AbstractTCKTest {
 		);
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.method( "returnStrings" )
 								.returnValue()
 								.containerElement( "<list element>", true, null, 1, List.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.method( "returnStrings" )
 								.returnValue()
 								.containerElement( "<list element>", true, null, 2, List.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotNull.class )
-						.propertyPath( pathWith()
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
 								.method( "returnStrings" )
 								.returnValue()
 								.containerElement( "<list element>", true, null, 2, List.class, 0 )
@@ -196,23 +181,20 @@ public class ContainerElementConstraintListTest extends AbstractTCKTest {
 		);
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.method( "setValues" )
 								.parameter( "listParameter", 0 )
 								.containerElement( "<list element>", true, null, 0, List.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.method( "setValues" )
 								.parameter( "listParameter", 0 )
 								.containerElement( "<list element>", true, null, 2, List.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotNull.class )
-						.propertyPath( pathWith()
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
 								.method( "setValues" )
 								.parameter( "listParameter", 0 )
 								.containerElement( "<list element>", true, null, 2, List.class, 0 )
@@ -234,23 +216,20 @@ public class ContainerElementConstraintListTest extends AbstractTCKTest {
 		);
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.constructor( TypeWithList6.class )
 								.parameter( "listParameter", 0 )
 								.containerElement( "<list element>", true, null, 0, List.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.constructor( TypeWithList6.class )
 								.parameter( "listParameter", 0 )
 								.containerElement( "<list element>", true, null, 2, List.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotNull.class )
-						.propertyPath( pathWith()
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
 								.constructor( TypeWithList6.class )
 								.parameter( "listParameter", 0 )
 								.containerElement( "<list element>", true, null, 2, List.class, 0 )

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/containerelement/ContainerElementConstraintMapKeyTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/containerelement/ContainerElementConstraintMapKeyTest.java
@@ -8,7 +8,7 @@ package org.hibernate.beanvalidation.tck.tests.constraints.containerelement;
 
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
@@ -56,9 +56,8 @@ public class ContainerElementConstraintMapKeyTest extends AbstractTCKTest {
 		Set<ConstraintViolation<TypeWithMap1>> constraintViolations = getValidator().validate( m );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.property( "nameMap" )
 								.containerElement( "<map key>", true, "", null, Map.class, 0 )
 						)
@@ -76,9 +75,8 @@ public class ContainerElementConstraintMapKeyTest extends AbstractTCKTest {
 		Set<ConstraintViolation<TypeWithMap2>> constraintViolations = getValidator().validate( m );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.property( "nameMap" )
 								.containerElement( "<map key>", true, "", null, Map.class, 0 )
 						)
@@ -88,11 +86,7 @@ public class ContainerElementConstraintMapKeyTest extends AbstractTCKTest {
 		constraintViolations = getValidator().validate( m );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotNull.class )
-						.propertyPath( pathWith()
-								.property( "nameMap" )
-						)
+				violationOf( NotNull.class ).withProperty( "nameMap" )
 		);
 	}
 
@@ -110,21 +104,18 @@ public class ContainerElementConstraintMapKeyTest extends AbstractTCKTest {
 		Set<ConstraintViolation<TypeWithMap3>> constraintViolations = getValidator().validate( m );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.property( "stringMap" )
 								.containerElement( "<map key>", true, "", null, Map.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.property( "stringMap" )
 								.containerElement( "<map key>", true, null, null, Map.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotNull.class )
-						.propertyPath( pathWith()
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
 								.property( "stringMap" )
 								.containerElement( "<map key>", true, null, null, Map.class, 0 )
 						)
@@ -150,23 +141,20 @@ public class ContainerElementConstraintMapKeyTest extends AbstractTCKTest {
 		);
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.method( "returnStringMap" )
 								.returnValue()
 								.containerElement( "<map key>", true, "", null, Map.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.method( "returnStringMap" )
 								.returnValue()
 								.containerElement( "<map key>", true, null, null, Map.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotNull.class )
-						.propertyPath( pathWith()
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
 								.method( "returnStringMap" )
 								.returnValue()
 								.containerElement( "<map key>", true, null, null, Map.class, 0 )
@@ -194,23 +182,20 @@ public class ContainerElementConstraintMapKeyTest extends AbstractTCKTest {
 		);
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.method( "setValues" )
 								.parameter( "mapParameter", 0 )
 								.containerElement( "<map key>", true, "", null, Map.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.method( "setValues" )
 								.parameter( "mapParameter", 0 )
 								.containerElement( "<map key>", true, null, null, Map.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotNull.class )
-						.propertyPath( pathWith()
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
 								.method( "setValues" )
 								.parameter( "mapParameter", 0 )
 								.containerElement( "<map key>", true, null, null, Map.class, 0 )
@@ -237,23 +222,20 @@ public class ContainerElementConstraintMapKeyTest extends AbstractTCKTest {
 		);
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.constructor( TypeWithMap6.class )
 								.parameter( "mapParameter", 0 )
 								.containerElement( "<map key>", true, "", null, Map.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.constructor( TypeWithMap6.class )
 								.parameter( "mapParameter", 0 )
 								.containerElement( "<map key>", true, null, null, Map.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotNull.class )
-						.propertyPath( pathWith()
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
 								.constructor( TypeWithMap6.class )
 								.parameter( "mapParameter", 0 )
 								.containerElement( "<map key>", true, null, null, Map.class, 0 )

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/containerelement/ContainerElementConstraintMapValueTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/containerelement/ContainerElementConstraintMapValueTest.java
@@ -8,7 +8,7 @@ package org.hibernate.beanvalidation.tck.tests.constraints.containerelement;
 
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
@@ -56,9 +56,8 @@ public class ContainerElementConstraintMapValueTest extends AbstractTCKTest {
 		Set<ConstraintViolation<TypeWithMap1>> constraintViolations = getValidator().validate( m );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.property( "nameMap" )
 								.containerElement( "<map value>", true, "second", null, Map.class, 1 )
 						)
@@ -76,9 +75,8 @@ public class ContainerElementConstraintMapValueTest extends AbstractTCKTest {
 		Set<ConstraintViolation<TypeWithMap2>> constraintViolations = getValidator().validate( m );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.property( "nameMap" )
 								.containerElement( "<map value>", true, "second", null, Map.class, 1 )
 						)
@@ -88,11 +86,7 @@ public class ContainerElementConstraintMapValueTest extends AbstractTCKTest {
 		constraintViolations = getValidator().validate( m );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotNull.class )
-						.propertyPath( pathWith()
-								.property( "nameMap" )
-						)
+				violationOf( NotNull.class ).withProperty( "nameMap" )
 		);
 	}
 
@@ -110,21 +104,18 @@ public class ContainerElementConstraintMapValueTest extends AbstractTCKTest {
 		Set<ConstraintViolation<TypeWithMap3>> constraintViolations = getValidator().validate( m );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.property( "stringMap" )
 								.containerElement( "<map value>", true, "first", null, Map.class, 1 )
 						),
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.property( "stringMap" )
 								.containerElement( "<map value>", true, "third", null, Map.class, 1 )
 						),
-				violationWith()
-						.constraintType( NotNull.class )
-						.propertyPath( pathWith()
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
 								.property( "stringMap" )
 								.containerElement( "<map value>", true, "third", null, Map.class, 1 )
 						)
@@ -150,23 +141,20 @@ public class ContainerElementConstraintMapValueTest extends AbstractTCKTest {
 		);
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.method( "returnStringMap" )
 								.returnValue()
 								.containerElement( "<map value>", true, "second", null, Map.class, 1 )
 						),
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.method( "returnStringMap" )
 								.returnValue()
 								.containerElement( "<map value>", true, "third", null, Map.class, 1 )
 						),
-				violationWith()
-						.constraintType( NotNull.class )
-						.propertyPath( pathWith()
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
 								.method( "returnStringMap" )
 								.returnValue()
 								.containerElement( "<map value>", true, "third", null, Map.class, 1 )
@@ -194,23 +182,20 @@ public class ContainerElementConstraintMapValueTest extends AbstractTCKTest {
 		);
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.method( "setValues" )
 								.parameter( "mapParameter", 0 )
 								.containerElement( "<map value>", true, "second", null, Map.class, 1 )
 						),
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.method( "setValues" )
 								.parameter( "mapParameter", 0 )
 								.containerElement( "<map value>", true, "third", null, Map.class, 1 )
 						),
-				violationWith()
-						.constraintType( NotNull.class )
-						.propertyPath( pathWith()
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
 								.method( "setValues" )
 								.parameter( "mapParameter", 0 )
 								.containerElement( "<map value>", true, "third", null, Map.class, 1 )
@@ -237,23 +222,20 @@ public class ContainerElementConstraintMapValueTest extends AbstractTCKTest {
 		);
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.constructor( TypeWithMap6.class )
 								.parameter( "mapParameter", 0 )
 								.containerElement( "<map value>", true, "second", null, Map.class, 1 )
 						),
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.constructor( TypeWithMap6.class )
 								.parameter( "mapParameter", 0 )
 								.containerElement( "<map value>", true, "third", null, Map.class, 1 )
 						),
-				violationWith()
-						.constraintType( NotNull.class )
-						.propertyPath( pathWith()
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
 								.constructor( TypeWithMap6.class )
 								.parameter( "mapParameter", 0 )
 								.containerElement( "<map value>", true, "third", null, Map.class, 1 )

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/containerelement/ContainerElementConstraintOptionalTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/containerelement/ContainerElementConstraintOptionalTest.java
@@ -8,7 +8,7 @@ package org.hibernate.beanvalidation.tck.tests.constraints.containerelement;
 
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
@@ -55,9 +55,7 @@ public class ContainerElementConstraintOptionalTest extends AbstractTCKTest {
 		Set<ConstraintViolation<TypeWithOptional1>> constraintViolations = getValidator().validate( o );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith().property( "stringOptional" ) )
+				violationOf( NotBlank.class ).withProperty( "stringOptional" )
 		);
 	}
 
@@ -69,9 +67,7 @@ public class ContainerElementConstraintOptionalTest extends AbstractTCKTest {
 		Set<ConstraintViolation<TypeWithOptional2>> constraintViolations = getValidator().validate( o );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith().property( "stringOptional" ) )
+				violationOf( NotBlank.class ).withProperty( "stringOptional" )
 		);
 
 		o = new TypeWithOptional2();
@@ -79,9 +75,7 @@ public class ContainerElementConstraintOptionalTest extends AbstractTCKTest {
 		constraintViolations = getValidator().validate( o );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotNull.class )
-						.propertyPath( pathWith().property( "stringOptional" ) )
+				violationOf( NotNull.class ).withProperty( "stringOptional" )
 		);
 	}
 
@@ -96,9 +90,7 @@ public class ContainerElementConstraintOptionalTest extends AbstractTCKTest {
 		Set<ConstraintViolation<TypeWithOptional3>> constraintViolations = getValidator().validate( o );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith().property( "stringOptional" ) )
+				violationOf( NotBlank.class ).withProperty( "stringOptional" )
 		);
 	}
 
@@ -115,9 +107,8 @@ public class ContainerElementConstraintOptionalTest extends AbstractTCKTest {
 		);
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.method( "returnStringOptional" )
 								.returnValue()
 						)
@@ -140,9 +131,8 @@ public class ContainerElementConstraintOptionalTest extends AbstractTCKTest {
 		);
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.method( "setValues" )
 								.parameter( "optionalParameter", 0 )
 						)
@@ -164,9 +154,8 @@ public class ContainerElementConstraintOptionalTest extends AbstractTCKTest {
 		);
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.constructor( TypeWithOptional6.class )
 								.parameter( "optionalParameter", 0 )
 						)

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/containerelement/ContainerElementConstraintSetTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/containerelement/ContainerElementConstraintSetTest.java
@@ -8,7 +8,7 @@ package org.hibernate.beanvalidation.tck.tests.constraints.containerelement;
 
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
@@ -55,21 +55,18 @@ public class ContainerElementConstraintSetTest extends AbstractTCKTest {
 		Set<ConstraintViolation<TypeWithSet1>> constraintViolations = getValidator().validate( s );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.property( "names" )
 								.containerElement( "<iterable element>", true, null, null, Set.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.property( "names" )
 								.containerElement( "<iterable element>", true, null, null, Set.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotNull.class )
-						.propertyPath( pathWith()
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
 								.property( "names" )
 								.containerElement( "<iterable element>", true, null, null, Set.class, 0 )
 						)
@@ -84,15 +81,13 @@ public class ContainerElementConstraintSetTest extends AbstractTCKTest {
 		Set<ConstraintViolation<TypeWithSet2>> constraintViolations = getValidator().validate( s );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.property( "names" )
 								.containerElement( "<iterable element>", true, null, null, Set.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.property( "names" )
 								.containerElement( "<iterable element>", true, null, null, Set.class, 0 )
 						)
@@ -103,11 +98,7 @@ public class ContainerElementConstraintSetTest extends AbstractTCKTest {
 		constraintViolations = getValidator().validate( s );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( Size.class )
-						.propertyPath( pathWith()
-								.property( "names" )
-						)
+				violationOf( Size.class ).withProperty( "names" )
 		);
 	}
 
@@ -125,21 +116,18 @@ public class ContainerElementConstraintSetTest extends AbstractTCKTest {
 		Set<ConstraintViolation<TypeWithSet3>> constraintViolations = getValidator().validate( s );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.property( "strings" )
 								.containerElement( "<iterable element>", true, null, null, Set.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.property( "strings" )
 								.containerElement( "<iterable element>", true, null, null, Set.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotNull.class )
-						.propertyPath( pathWith()
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
 								.property( "strings" )
 								.containerElement( "<iterable element>", true, null, null, Set.class, 0 )
 						)
@@ -159,23 +147,20 @@ public class ContainerElementConstraintSetTest extends AbstractTCKTest {
 		);
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.method( "returnStrings" )
 								.returnValue()
 								.containerElement( "<iterable element>", true, null, null, Set.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.method( "returnStrings" )
 								.returnValue()
 								.containerElement( "<iterable element>", true, null, null, Set.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotNull.class )
-						.propertyPath( pathWith()
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
 								.method( "returnStrings" )
 								.returnValue()
 								.containerElement( "<iterable element>", true, null, null, Set.class, 0 )
@@ -198,23 +183,20 @@ public class ContainerElementConstraintSetTest extends AbstractTCKTest {
 		);
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.method( "setValues" )
 								.parameter( "setParameter", 0 )
 								.containerElement( "<iterable element>", true, null, null, Set.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.method( "setValues" )
 								.parameter( "setParameter", 0 )
 								.containerElement( "<iterable element>", true, null, null, Set.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotNull.class )
-						.propertyPath( pathWith()
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
 								.method( "setValues" )
 								.parameter( "setParameter", 0 )
 								.containerElement( "<iterable element>", true, null, null, Set.class, 0 )
@@ -236,23 +218,20 @@ public class ContainerElementConstraintSetTest extends AbstractTCKTest {
 		);
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.constructor( TypeWithSet6.class )
 								.parameter( "setParameter", 0 )
 								.containerElement( "<iterable element>", true, null, null, Set.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.constructor( TypeWithSet6.class )
 								.parameter( "setParameter", 0 )
 								.containerElement( "<iterable element>", true, null, null, Set.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotNull.class )
-						.propertyPath( pathWith()
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
 								.constructor( TypeWithSet6.class )
 								.parameter( "setParameter", 0 )
 								.containerElement( "<iterable element>", true, null, null, Set.class, 0 )

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/containerelement/NestedContainerElementConstraintsTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/containerelement/NestedContainerElementConstraintsTest.java
@@ -9,7 +9,7 @@ package org.hibernate.beanvalidation.tck.tests.constraints.containerelement;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -53,9 +53,8 @@ public class NestedContainerElementConstraintsTest extends AbstractTCKTest {
 
 		constraintViolations = getValidator().validate( MapOfLists.invalidKey() );
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( Size.class )
-						.propertyPath( pathWith()
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
 								.property( "map" )
 								.containerElement( "<map key>", true, "k", null, Map.class, 0 )
 						)
@@ -63,9 +62,8 @@ public class NestedContainerElementConstraintsTest extends AbstractTCKTest {
 
 		constraintViolations = getValidator().validate( MapOfLists.invalidList() );
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( Size.class )
-						.propertyPath( pathWith()
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
 								.property( "map" )
 								.containerElement( "<map value>", true, "key1", null, Map.class, 1 )
 						)
@@ -73,16 +71,14 @@ public class NestedContainerElementConstraintsTest extends AbstractTCKTest {
 
 		constraintViolations = getValidator().validate( MapOfLists.invalidString() );
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( Size.class )
-						.propertyPath( pathWith()
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
 								.property( "map" )
 								.containerElement( "<map value>", true, "key1", null, Map.class, 1 )
 								.containerElement( "<list element>", true, null, 0, List.class, 0 )
 						),
-				violationWith()
-						.constraintType( Size.class )
-						.propertyPath( pathWith()
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
 								.property( "map" )
 								.containerElement( "<map value>", true, "key1", null, Map.class, 1 )
 								.containerElement( "<list element>", true, null, 1, List.class, 0 )
@@ -91,21 +87,18 @@ public class NestedContainerElementConstraintsTest extends AbstractTCKTest {
 
 		constraintViolations = getValidator().validate( MapOfLists.reallyInvalid() );
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( Size.class )
-						.propertyPath( pathWith()
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
 								.property( "map" )
 								.containerElement( "<map key>", true, "k", null, Map.class, 0 )
 						),
-				violationWith()
-						.constraintType( Size.class )
-						.propertyPath( pathWith()
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
 								.property( "map" )
 								.containerElement( "<map value>", true, "k", null, Map.class, 1 )
 						),
-				violationWith()
-						.constraintType( Size.class )
-						.propertyPath( pathWith()
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
 								.property( "map" )
 								.containerElement( "<map value>", true, "k", null, Map.class, 1 )
 								.containerElement( "<list element>", true, null, 0, List.class, 0 )
@@ -121,9 +114,8 @@ public class NestedContainerElementConstraintsTest extends AbstractTCKTest {
 
 		constraintViolations = getValidator().validate( MapOfListsWithAutomaticUnwrapping.invalidStringProperty() );
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( Size.class )
-						.propertyPath( pathWith()
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
 								.property( "map" )
 								.containerElement( "<map value>", true, "key", null, Map.class, 1 )
 								.containerElement( "<list element>", true, null, 1, List.class, 0 )
@@ -132,9 +124,8 @@ public class NestedContainerElementConstraintsTest extends AbstractTCKTest {
 
 		constraintViolations = getValidator().validate( MapOfListsWithAutomaticUnwrapping.invalidListElement() );
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotNull.class )
-						.propertyPath( pathWith()
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
 								.property( "map" )
 								.containerElement( "<map value>", true, "key", null, Map.class, 1 )
 								.containerElement( "<list element>", true, null, 0, List.class, 0 )
@@ -148,16 +139,14 @@ public class NestedContainerElementConstraintsTest extends AbstractTCKTest {
 		Set<ConstraintViolation<MapOfListsUsingGetter>> constraintViolations = getValidator().validate( MapOfListsUsingGetter.invalidString() );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( Size.class )
-						.propertyPath( pathWith()
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
 								.property( "map" )
 								.containerElement( "<map value>", true, "key1", null, Map.class, 1 )
 								.containerElement( "<list element>", true, null, 0, List.class, 0 )
 						),
-				violationWith()
-						.constraintType( Size.class )
-						.propertyPath( pathWith()
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
 								.property( "map" )
 								.containerElement( "<map value>", true, "key1", null, Map.class, 1 )
 								.containerElement( "<list element>", true, null, 1, List.class, 0 )

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/containerelement/SameElementContainedSeveralTimesInCollectionTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/containerelement/SameElementContainedSeveralTimesInCollectionTest.java
@@ -8,7 +8,7 @@ package org.hibernate.beanvalidation.tck.tests.constraints.containerelement;
 
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -50,15 +50,13 @@ public class SameElementContainedSeveralTimesInCollectionTest extends AbstractTC
 		Set<ConstraintViolation<ListContainer>> constraintViolations = getValidator().validate( listContainer );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( Size.class )
-						.propertyPath( pathWith()
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
 								.property( "values" )
 								.containerElement( "<list element>", true, null, 0, List.class, 0 )
 						),
-				violationWith()
-						.constraintType( Size.class )
-						.propertyPath( pathWith()
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
 								.property( "values" )
 								.containerElement( "<list element>", true, null, 2, List.class, 0 )
 						)
@@ -80,15 +78,13 @@ public class SameElementContainedSeveralTimesInCollectionTest extends AbstractTC
 		Set<ConstraintViolation<MapContainer>> constraintViolations = getValidator().validate( withMap );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( Size.class )
-						.propertyPath( pathWith()
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
 								.property( "values" )
 								.containerElement( "<map value>", true, "EMPTY_1", null, Map.class, 1 )
 						),
-				violationWith()
-						.constraintType( Size.class )
-						.propertyPath( pathWith()
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
 								.property( "values" )
 								.containerElement( "<map value>", true, "EMPTY_2", null, Map.class, 1 )
 						)

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/graphnavigation/containerelement/CascadingOnContainerElementsTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/graphnavigation/containerelement/CascadingOnContainerElementsTest.java
@@ -8,7 +8,7 @@ package org.hibernate.beanvalidation.tck.tests.validation.graphnavigation.contai
 
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -58,15 +58,13 @@ public class CascadingOnContainerElementsTest extends AbstractTCKTest {
 		Set<ConstraintViolation<TypeWithList>> constraintViolations = getValidator().validate( l );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( Min.class )
-						.propertyPath( pathWith()
+				violationOf( Min.class )
+						.withPropertyPath( pathWith()
 								.property( "bars" )
 								.property( "number", true, null, 0, List.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotNull.class )
-						.propertyPath( pathWith()
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
 								.property( "bars" )
 								.containerElement( "<list element>", true, null, 1, List.class, 0 )
 						)
@@ -88,15 +86,13 @@ public class CascadingOnContainerElementsTest extends AbstractTCKTest {
 		Set<ConstraintViolation<TypeWithMapValue>> constraintViolations = getValidator().validate( m );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( Min.class )
-						.propertyPath( pathWith()
+				violationOf( Min.class )
+						.withPropertyPath( pathWith()
 								.property( "barMap" )
 								.property( "number", true, "bar", null, Map.class, 1 )
 						),
-				violationWith()
-						.constraintType( NotNull.class )
-						.propertyPath( pathWith()
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
 								.property( "barMap" )
 								.containerElement( "<map value>", true, "foo", null, Map.class, 1 )
 						)
@@ -119,15 +115,13 @@ public class CascadingOnContainerElementsTest extends AbstractTCKTest {
 		Set<ConstraintViolation<TypeWithMapKey>> constraintViolations = getValidator().validate( m );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( Min.class )
-						.propertyPath( pathWith()
+				violationOf( Min.class )
+						.withPropertyPath( pathWith()
 								.property( "barMap" )
 								.property( "number", true, bar, null, Map.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotNull.class )
-						.propertyPath( pathWith()
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
 								.property( "barMap" )
 								.containerElement( "<map key>", true, null, null, Map.class, 0 )
 						)
@@ -147,9 +141,7 @@ public class CascadingOnContainerElementsTest extends AbstractTCKTest {
 		Set<ConstraintViolation<TypeWithOptional>> constraintViolations = getValidator().validate( o );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotNull.class )
-						.propertyPath( pathWith().property( "bar" ) )
+				violationOf( NotNull.class ).withProperty( "bar" )
 		);
 
 		o = new TypeWithOptional();
@@ -157,9 +149,8 @@ public class CascadingOnContainerElementsTest extends AbstractTCKTest {
 		constraintViolations = getValidator().validate( o );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( Min.class )
-						.propertyPath( pathWith()
+				violationOf( Min.class )
+						.withPropertyPath( pathWith()
 								.property( "bar" )
 								.property( "number", false, null, null, Optional.class, 0 )
 						)
@@ -179,15 +170,13 @@ public class CascadingOnContainerElementsTest extends AbstractTCKTest {
 		Set<ConstraintViolation<TypeWithSet>> constraintViolations = getValidator().validate( s );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( Min.class )
-						.propertyPath( pathWith()
+				violationOf( Min.class )
+						.withPropertyPath( pathWith()
 								.property( "bars" )
 								.property( "number", true, null, null, Set.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotNull.class )
-						.propertyPath( pathWith()
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
 								.property( "bars" )
 								.containerElement( "<iterable element>", true, null, null, Set.class, 0 )
 						)

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/graphnavigation/containerelement/NestedCascadingOnContainerElementsTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/graphnavigation/containerelement/NestedCascadingOnContainerElementsTest.java
@@ -9,7 +9,7 @@ package org.hibernate.beanvalidation.tck.tests.validation.graphnavigation.contai
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -65,16 +65,14 @@ public class NestedCascadingOnContainerElementsTest extends AbstractTCKTest {
 		constraintViolations = validator.validate( EmailAddressMap.invalidEmailAddressMap() );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.property( "map" )
 								.containerElement( "<map value>", true, "invalid", null, Map.class, 1 )
 								.property( "email", true, null, 1, List.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.property( "map" )
 								.containerElement( "<map value>", true, "invalid", null, Map.class, 1 )
 								.property( "email", true, null, 2, List.class, 0 )
@@ -100,23 +98,20 @@ public class NestedCascadingOnContainerElementsTest extends AbstractTCKTest {
 		constraintViolations = validator.validate( invalidCinemaEmailAddresses );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.property( "map" )
 								.containerElement( "<map value>", true, invalidCinemaEmailAddresses.map.keySet().toArray()[1], null, Map.class, 1 )
 								.property( "email", true, null, 1, List.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.property( "map" )
 								.containerElement( "<map value>", true, invalidCinemaEmailAddresses.map.keySet().toArray()[1], null, Map.class, 1 )
 								.property( "email", true, null, 2, List.class, 0 )
 						),
-				violationWith()
-						.constraintType( NotNull.class )
-						.propertyPath( pathWith()
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
 								.property( "map" )
 								.containerElement( "<map value>", true, invalidCinemaEmailAddresses.map.keySet().toArray()[2], null, Map.class, 1 )
 								.containerElement( "<list element>", true, null, 0, List.class, 0 )
@@ -127,9 +122,8 @@ public class NestedCascadingOnContainerElementsTest extends AbstractTCKTest {
 		constraintViolations = validator.validate( invalidKeyCinemaEmailAddresses );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotNull.class )
-						.propertyPath( pathWith()
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
 								.property( "map" )
 								.containerElement( "<map key>", true, invalidKeyCinemaEmailAddresses.map.keySet().toArray()[1], null, Map.class, 0 )
 								.property( "visitor", Optional.class, 0 )
@@ -156,9 +150,8 @@ public class NestedCascadingOnContainerElementsTest extends AbstractTCKTest {
 		constraintViolations = validator.validate( NestedCascadingListWithValidAllAlongTheWay.withNullList() );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotNull.class )
-						.propertyPath( pathWith()
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
 								.property( "list" )
 								.containerElement( "<list element>", true, null, 0, List.class, 0 )
 						)

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/builtin/JavaFXValueExtractorsTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/builtin/JavaFXValueExtractorsTest.java
@@ -9,7 +9,7 @@ package org.hibernate.beanvalidation.tck.tests.valueextraction.builtin;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.util.Set;
 
@@ -73,18 +73,10 @@ public class JavaFXValueExtractorsTest extends AbstractTCKTest {
 		Set<ConstraintViolation<BasicPropertiesEntity>> constraintViolations = getValidator().validate( new BasicPropertiesEntity() );
 
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotNull.class )
-						.propertyPath( pathWith().property( "stringProperty" ) ),
-				violationWith()
-						.constraintType( Max.class )
-						.propertyPath( pathWith().property( "doubleProperty" ) ),
-				violationWith()
-						.constraintType( Min.class )
-						.propertyPath( pathWith().property( "integerProperty" ) ),
-				violationWith()
-						.constraintType( AssertTrue.class )
-						.propertyPath( pathWith().property( "booleanProperty" ) )
+				violationOf( NotNull.class ).withProperty( "stringProperty" ),
+				violationOf( Max.class ).withProperty( "doubleProperty" ),
+				violationOf( Min.class ).withProperty( "integerProperty" ),
+				violationOf( AssertTrue.class ).withProperty( "booleanProperty" )
 		);
 	}
 
@@ -98,16 +90,13 @@ public class JavaFXValueExtractorsTest extends AbstractTCKTest {
 
 		constraintViolations = validator.validate( ListPropertyEntity.invalidList() );
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( Size.class )
-						.propertyPath( pathWith().property( "listProperty" ) )
+				violationOf( Size.class ).withProperty( "listProperty" )
 		);
 
 		constraintViolations = validator.validate( ListPropertyEntity.invalidListElement() );
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( Size.class )
-						.propertyPath( pathWith()
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
 								.property( "listProperty" )
 								.containerElement( "<list element>", true, null, 0, ListProperty.class, 0 ) )
 		);
@@ -123,16 +112,13 @@ public class JavaFXValueExtractorsTest extends AbstractTCKTest {
 
 		constraintViolations = validator.validate( SetPropertyEntity.invalidSet() );
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( Size.class )
-						.propertyPath( pathWith().property( "setProperty" ) )
+				violationOf( Size.class ).withProperty( "setProperty" )
 		);
 
 		constraintViolations = validator.validate( SetPropertyEntity.invalidSetElement() );
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( Size.class )
-						.propertyPath( pathWith()
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
 								.property( "setProperty" )
 								.containerElement( "<iterable element>", true, null, null, SetProperty.class, 0 ) )
 		);
@@ -148,25 +134,21 @@ public class JavaFXValueExtractorsTest extends AbstractTCKTest {
 
 		constraintViolations = validator.validate( MapPropertyEntity.invalidMap() );
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( Size.class )
-						.propertyPath( pathWith().property( "mapProperty" ) )
+				violationOf( Size.class ).withProperty( "mapProperty" )
 		);
 
 		constraintViolations = validator.validate( MapPropertyEntity.invalidMapKey() );
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( Size.class )
-						.propertyPath( pathWith()
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
 								.property( "mapProperty" )
 								.containerElement( "<map key>", true, "app", null, MapProperty.class, 0 ) )
 		);
 
 		constraintViolations = validator.validate( MapPropertyEntity.invalidMapValue() );
 		assertThat( constraintViolations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( NotBlank.class )
-						.propertyPath( pathWith()
+				violationOf( NotBlank.class )
+						.withPropertyPath( pathWith()
 								.property( "mapProperty" )
 								.containerElement( "<map value>", true, "pear", null, MapProperty.class, 1 ) )
 		);

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/definition/ValueExtractorDefinitionTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/definition/ValueExtractorDefinitionTest.java
@@ -8,7 +8,7 @@ package org.hibernate.beanvalidation.tck.tests.valueextraction.definition;
 
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 import static org.testng.Assert.assertEquals;
 
 import java.util.HashMap;
@@ -197,19 +197,16 @@ public class ValueExtractorDefinitionTest extends AbstractTCKTest {
 
 		Set<ConstraintViolation<MapHolder>> violations = validator.validate( mapHolder );
 		assertThat( violations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( RetailOrder.class )
-						.propertyPath( pathWith()
+				violationOf( RetailOrder.class )
+						.withPropertyPath( pathWith()
 								.property( "ordersByName" )
 								.containerElement( "<map value>", true, "name1", null, Map.class, 1 ) ),
-				violationWith()
-						.constraintType( NotNull.class )
-						.propertyPath( pathWith()
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
 								.property( "ordersByName" )
 								.property( "id", true, "name2", null, Map.class, 1 ) ),
-				violationWith()
-						.constraintType( NotNull.class )
-						.propertyPath( pathWith()
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
 								.property( "ordersByName" )
 								.containerElement( "<map key>", true, null, null, Map.class, 0 ) )
 		);

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/ContainerElementTypeConstraintsForFieldXmlMappingTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/ContainerElementTypeConstraintsForFieldXmlMappingTest.java
@@ -7,7 +7,7 @@
 package org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel;
 
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -69,21 +69,11 @@ public class ContainerElementTypeConstraintsForFieldXmlMappingTest extends Abstr
 		Set<ConstraintViolation<FishTank>> violations = validator.validate( new FishTank() );
 
 		assertThat( violations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( Size.class )
-						.message( "size must be between 0 and 5" ),
-				violationWith()
-						.constraintType( Size.class )
-						.message( "size must be between 3 and 10" ),
-				violationWith()
-						.constraintType( Size.class )
-						.message( "size must be between 3 and 10" ),
-				violationWith()
-						.constraintType( Min.class )
-						.message( "must be greater than or equal to 1" ),
-				violationWith()
-						.constraintType( Min.class )
-						.message( "must be greater than or equal to 1" )
+				violationOf( Size.class ).withMessage( "size must be between 0 and 5" ),
+				violationOf( Size.class ).withMessage( "size must be between 3 and 10" ),
+				violationOf( Size.class ).withMessage( "size must be between 3 and 10" ),
+				violationOf( Min.class ).withMessage( "must be greater than or equal to 1" ),
+				violationOf( Min.class ).withMessage( "must be greater than or equal to 1" )
 		);
 	}
 
@@ -99,7 +89,7 @@ public class ContainerElementTypeConstraintsForFieldXmlMappingTest extends Abstr
 		Set<ConstraintViolation<FishTank>> violations = validator.validate( new FishTank() );
 
 		assertThat( violations ).containsOnlyViolations(
-				violationWith().constraintType( NotNull.class )
+				violationOf( NotNull.class )
 		);
 	}
 
@@ -115,7 +105,7 @@ public class ContainerElementTypeConstraintsForFieldXmlMappingTest extends Abstr
 		Set<ConstraintViolation<FishTank>> violations = validator.validate( new FishTank() );
 
 		assertThat( violations ).containsOnlyViolations(
-				violationWith().constraintType( NotNull.class )
+				violationOf( NotNull.class )
 		);
 	}
 
@@ -130,7 +120,7 @@ public class ContainerElementTypeConstraintsForFieldXmlMappingTest extends Abstr
 		Set<ConstraintViolation<FishTank>> violations = validator.validate( new FishTank() );
 
 		assertThat( violations ).containsOnlyViolations(
-				violationWith().constraintType( NotNull.class )
+				violationOf( NotNull.class )
 		);
 	}
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/ContainerElementTypeConstraintsForGetterXmlMappingTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/ContainerElementTypeConstraintsForGetterXmlMappingTest.java
@@ -7,7 +7,7 @@
 package org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel;
 
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -69,21 +69,11 @@ public class ContainerElementTypeConstraintsForGetterXmlMappingTest extends Abst
 		Set<ConstraintViolation<FishTank>> violations = validator.validate( new FishTank() );
 
 		assertThat( violations ).containsOnlyViolations(
-				violationWith()
-						.constraintType( Size.class )
-						.message( "size must be between 0 and 5" ),
-				violationWith()
-						.constraintType( Size.class )
-						.message( "size must be between 3 and 10" ),
-				violationWith()
-						.constraintType( Size.class )
-						.message( "size must be between 3 and 10" ),
-				violationWith()
-						.constraintType( Min.class )
-						.message( "must be greater than or equal to 1" ),
-				violationWith()
-						.constraintType( Min.class )
-						.message( "must be greater than or equal to 1" )
+				violationOf( Size.class ).withMessage( "size must be between 0 and 5" ),
+				violationOf( Size.class ).withMessage( "size must be between 3 and 10" ),
+				violationOf( Size.class ).withMessage( "size must be between 3 and 10" ),
+				violationOf( Min.class ).withMessage( "must be greater than or equal to 1" ),
+				violationOf( Min.class ).withMessage( "must be greater than or equal to 1" )
 		);
 	}
 
@@ -99,7 +89,7 @@ public class ContainerElementTypeConstraintsForGetterXmlMappingTest extends Abst
 		Set<ConstraintViolation<FishTank>> violations = validator.validate( new FishTank() );
 
 		assertThat( violations ).containsOnlyViolations(
-				violationWith().constraintType( NotNull.class )
+				violationOf( NotNull.class )
 		);
 	}
 
@@ -115,7 +105,7 @@ public class ContainerElementTypeConstraintsForGetterXmlMappingTest extends Abst
 		Set<ConstraintViolation<FishTank>> violations = validator.validate( new FishTank() );
 
 		assertThat( violations ).containsOnlyViolations(
-				violationWith().constraintType( NotNull.class )
+				violationOf( NotNull.class )
 		);
 	}
 
@@ -130,7 +120,7 @@ public class ContainerElementTypeConstraintsForGetterXmlMappingTest extends Abst
 		Set<ConstraintViolation<FishTank>> violations = validator.validate( new FishTank() );
 
 		assertThat( violations ).containsOnlyViolations(
-				violationWith().constraintType( NotNull.class )
+				violationOf( NotNull.class )
 		);
 	}
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/ContainerElementTypeConstraintsForParameterXmlMappingTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/ContainerElementTypeConstraintsForParameterXmlMappingTest.java
@@ -8,7 +8,7 @@ package org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclar
 
 import static org.assertj.core.api.Assertions.fail;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -79,21 +79,11 @@ public class ContainerElementTypeConstraintsForParameterXmlMappingTest extends A
 		}
 		catch (ConstraintViolationException e) {
 			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
-					violationWith()
-							.constraintType( Size.class )
-							.message( "size must be between 0 and 5" ),
-					violationWith()
-							.constraintType( Size.class )
-							.message( "size must be between 3 and 10" ),
-					violationWith()
-							.constraintType( Size.class )
-							.message( "size must be between 3 and 10" ),
-					violationWith()
-							.constraintType( Min.class )
-							.message( "must be greater than or equal to 1" ),
-					violationWith()
-							.constraintType( Min.class )
-							.message( "must be greater than or equal to 1" )
+					violationOf( Size.class ).withMessage( "size must be between 0 and 5" ),
+					violationOf( Size.class ).withMessage( "size must be between 3 and 10" ),
+					violationOf( Size.class ).withMessage( "size must be between 3 and 10" ),
+					violationOf( Min.class ).withMessage( "must be greater than or equal to 1" ),
+					violationOf( Min.class ).withMessage( "must be greater than or equal to 1" )
 			);
 		}
 	}
@@ -120,7 +110,7 @@ public class ContainerElementTypeConstraintsForParameterXmlMappingTest extends A
 		}
 		catch (ConstraintViolationException e) {
 			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
-					violationWith().constraintType( NotNull.class )
+					violationOf( NotNull.class )
 			);
 		}
 	}
@@ -149,7 +139,7 @@ public class ContainerElementTypeConstraintsForParameterXmlMappingTest extends A
 		}
 		catch (ConstraintViolationException e) {
 			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
-					violationWith().constraintType( NotNull.class )
+					violationOf( NotNull.class )
 			);
 		}
 	}
@@ -172,7 +162,7 @@ public class ContainerElementTypeConstraintsForParameterXmlMappingTest extends A
 		}
 		catch (ConstraintViolationException e) {
 			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
-					violationWith().constraintType( NotNull.class )
+					violationOf( NotNull.class )
 			);
 		}
 	}

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/ContainerElementTypeConstraintsForReturnValueXmlMappingTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/ContainerElementTypeConstraintsForReturnValueXmlMappingTest.java
@@ -8,7 +8,7 @@ package org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclar
 
 import static org.assertj.core.api.Assertions.fail;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -76,18 +76,10 @@ public class ContainerElementTypeConstraintsForReturnValueXmlMappingTest extends
 		}
 		catch (ConstraintViolationException e) {
 			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
-					violationWith()
-							.constraintType( Size.class )
-							.message( "size must be between 3 and 10" ),
-					violationWith()
-							.constraintType( Size.class )
-							.message( "size must be between 3 and 10" ),
-					violationWith()
-							.constraintType( Min.class )
-							.message( "must be greater than or equal to 1" ),
-					violationWith()
-							.constraintType( Min.class )
-							.message( "must be greater than or equal to 1" )
+					violationOf( Size.class ).withMessage( "size must be between 3 and 10" ),
+					violationOf( Size.class ).withMessage( "size must be between 3 and 10" ),
+					violationOf( Min.class ).withMessage( "must be greater than or equal to 1" ),
+					violationOf( Min.class ).withMessage( "must be greater than or equal to 1" )
 			);
 		}
 	}
@@ -110,7 +102,7 @@ public class ContainerElementTypeConstraintsForReturnValueXmlMappingTest extends
 		}
 		catch (ConstraintViolationException e) {
 			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
-					violationWith().constraintType( NotNull.class )
+					violationOf( NotNull.class )
 			);
 		}
 	}
@@ -133,7 +125,7 @@ public class ContainerElementTypeConstraintsForReturnValueXmlMappingTest extends
 		}
 		catch (ConstraintViolationException e) {
 			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
-					violationWith().constraintType( NotNull.class )
+					violationOf( NotNull.class )
 			);
 		}
 	}
@@ -155,7 +147,7 @@ public class ContainerElementTypeConstraintsForReturnValueXmlMappingTest extends
 		}
 		catch (ConstraintViolationException e) {
 			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
-					violationWith().constraintType( NotNull.class )
+					violationOf( NotNull.class )
 			);
 		}
 	}

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/ContainerElementTypeIgnoreAnnotationsMappingTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/ContainerElementTypeIgnoreAnnotationsMappingTest.java
@@ -7,7 +7,7 @@
 package org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel;
 
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.math.BigDecimal;
 import java.util.HashMap;
@@ -59,7 +59,7 @@ public class ContainerElementTypeIgnoreAnnotationsMappingTest extends AbstractTC
 		Set<ConstraintViolation<OrderField>> violations = validator.validate( OrderField.invalid() );
 
 		assertThat( violations ).containsOnlyViolations(
-				violationWith().constraintType( DecimalMin.class )
+				violationOf( DecimalMin.class )
 		);
 
 		validator = getValidator( "field-ignoreAnnotationsFalse-mapping.xml" );
@@ -67,8 +67,8 @@ public class ContainerElementTypeIgnoreAnnotationsMappingTest extends AbstractTC
 		violations = validator.validate( OrderField.invalid() );
 
 		assertThat( violations ).containsOnlyViolations(
-				violationWith().constraintType( NotBlank.class ),
-				violationWith().constraintType( DecimalMin.class )
+				violationOf( NotBlank.class ),
+				violationOf( DecimalMin.class )
 		);
 	}
 
@@ -80,7 +80,7 @@ public class ContainerElementTypeIgnoreAnnotationsMappingTest extends AbstractTC
 		Set<ConstraintViolation<OrderGetter>> violations = validator.validate( OrderGetter.invalid() );
 
 		assertThat( violations ).containsOnlyViolations(
-				violationWith().constraintType( DecimalMin.class )
+				violationOf( DecimalMin.class )
 		);
 
 		validator = getValidator( "getter-ignoreAnnotationsFalse-mapping.xml" );
@@ -88,8 +88,8 @@ public class ContainerElementTypeIgnoreAnnotationsMappingTest extends AbstractTC
 		violations = validator.validate( OrderGetter.invalid() );
 
 		assertThat( violations ).containsOnlyViolations(
-				violationWith().constraintType( NotBlank.class ),
-				violationWith().constraintType( DecimalMin.class )
+				violationOf( NotBlank.class ),
+				violationOf( DecimalMin.class )
 		);
 	}
 
@@ -104,7 +104,7 @@ public class ContainerElementTypeIgnoreAnnotationsMappingTest extends AbstractTC
 				OrderReturnValue.class.getMethod( "retrieveLines" ), invalidObject.lines );
 
 		assertThat( violations ).containsOnlyViolations(
-				violationWith().constraintType( DecimalMin.class )
+				violationOf( DecimalMin.class )
 		);
 
 		validator = getValidator( "returnvalue-ignoreAnnotationsFalse-mapping.xml" ).forExecutables();
@@ -113,8 +113,8 @@ public class ContainerElementTypeIgnoreAnnotationsMappingTest extends AbstractTC
 				OrderReturnValue.class.getMethod( "retrieveLines" ), invalidObject.lines );
 
 		assertThat( violations ).containsOnlyViolations(
-				violationWith().constraintType( NotBlank.class ),
-				violationWith().constraintType( DecimalMin.class )
+				violationOf( NotBlank.class ),
+				violationOf( DecimalMin.class )
 		);
 	}
 
@@ -131,7 +131,7 @@ public class ContainerElementTypeIgnoreAnnotationsMappingTest extends AbstractTC
 				OrderParameter.class.getMethod( "addLines", Map.class ), new Object[] { additionalLines } );
 
 		assertThat( violations ).containsOnlyViolations(
-				violationWith().constraintType( DecimalMin.class )
+				violationOf( DecimalMin.class )
 		);
 
 		validator = getValidator( "parameter-ignoreAnnotationsFalse-mapping.xml" ).forExecutables();
@@ -140,8 +140,8 @@ public class ContainerElementTypeIgnoreAnnotationsMappingTest extends AbstractTC
 				OrderParameter.class.getMethod( "addLines", Map.class ), new Object[] { additionalLines } );
 
 		assertThat( violations ).containsOnlyViolations(
-				violationWith().constraintType( NotBlank.class ),
-				violationWith().constraintType( DecimalMin.class )
+				violationOf( NotBlank.class ),
+				violationOf( DecimalMin.class )
 		);
 	}
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/util/ConstraintViolationAssert.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/util/ConstraintViolationAssert.java
@@ -232,8 +232,8 @@ public final class ConstraintViolationAssert {
 		return new PathExpectation();
 	}
 
-	public static ViolationExpectation violationWith() {
-		return new ViolationExpectation();
+	public static ViolationExpectation violationOf(Class<? extends Annotation> constraintType) {
+		return new ViolationExpectation( constraintType );
 	}
 
 	public static class ConstraintViolationSetAssert extends IterableAssert<ConstraintViolation<?>> {
@@ -306,7 +306,7 @@ public final class ConstraintViolationAssert {
 
 		private final ViolationExpectationPropertiesToTest propertiesToTest = new ViolationExpectationPropertiesToTest();
 
-		private Class<? extends Annotation> constraintType;
+		private final Class<? extends Annotation> constraintType;
 
 		private Class<?> rootBeanClass;
 
@@ -316,64 +316,60 @@ public final class ConstraintViolationAssert {
 
 		private PathExpectation propertyPath;
 
-		public ViolationExpectation() {
+		public ViolationExpectation(Class<? extends Annotation> constraintType) {
+			this.constraintType = constraintType;
 		}
 
 		public ViolationExpectation(ConstraintViolation<?> violation, ViolationExpectationPropertiesToTest propertiesToTest) {
-			if ( propertiesToTest.testConstraintType ) {
-				constraintType( violation.getConstraintDescriptor().getAnnotation().annotationType() );
-			}
+			this.constraintType = violation.getConstraintDescriptor().getAnnotation().annotationType();
+
 			if ( propertiesToTest.testRootBeanClass ) {
-				rootBeanClass( violation.getRootBeanClass() );
+				withRootBeanClass( violation.getRootBeanClass() );
 			}
 			if ( propertiesToTest.testMessage ) {
-				message( violation.getMessage() );
+				withMessage( violation.getMessage() );
 			}
 			if ( propertiesToTest.testInvalidValue ) {
-				invalidValue( violation.getInvalidValue() );
+				withInvalidValue( violation.getInvalidValue() );
 			}
 			if ( propertiesToTest.testPropertyPath ) {
-				propertyPath( new PathExpectation( violation.getPropertyPath() ) );
+				withPropertyPath( new PathExpectation( violation.getPropertyPath() ) );
 			}
 		}
 
-		public ViolationExpectation constraintType(Class<? extends Annotation> constraint) {
-			propertiesToTest.testConstraintType();
-			this.constraintType = constraint;
-			return this;
-		}
-
-		public ViolationExpectation rootBeanClass(Class<?> rootBeanClass) {
+		public ViolationExpectation withRootBeanClass(Class<?> rootBeanClass) {
 			propertiesToTest.testRootBeanClass();
 			this.rootBeanClass = rootBeanClass;
 			return this;
 		}
 
-		public ViolationExpectation message(String message) {
+		public ViolationExpectation withMessage(String message) {
 			propertiesToTest.testMessage();
 			this.message = message;
 			return this;
 		}
 
-		public ViolationExpectation invalidValue(Object invalidValue) {
+		public ViolationExpectation withInvalidValue(Object invalidValue) {
 			propertiesToTest.testInvalidValue();
 			this.invalidValue = invalidValue;
 			return this;
 		}
 
-		public ViolationExpectation propertyPath(PathExpectation propertyPath) {
+		public ViolationExpectation withPropertyPath(PathExpectation propertyPath) {
 			propertiesToTest.testPropertyPath();
 			this.propertyPath = propertyPath;
 			return this;
+		}
+
+		public ViolationExpectation withProperty(String property) {
+			return withPropertyPath( pathWith().property( property ) );
 		}
 
 		@Override
 		public String toString() {
 			String lineBreak = System.getProperty( "line.separator" );
 			StringBuilder asString = new StringBuilder( lineBreak + "ViolationExpectation(" + lineBreak );
-			if ( propertiesToTest.testConstraintType ) {
-				asString.append( "  constraintType: " ).append( constraintType ).append( lineBreak );
-			}
+			asString.append( "  constraintType: " ).append( constraintType ).append( lineBreak );
 			if ( propertiesToTest.testRootBeanClass ) {
 				asString.append( "  rootBeanClass: " ).append( rootBeanClass ).append( lineBreak );
 			}
@@ -394,9 +390,7 @@ public final class ConstraintViolationAssert {
 		public int hashCode() {
 			final int prime = 31;
 			int result = 1;
-			if ( propertiesToTest.testConstraintType ) {
-				result = prime * result + ( constraintType == null ? 0 : constraintType.hashCode() );
-			}
+			result = prime * result + ( constraintType == null ? 0 : constraintType.hashCode() );
 			if ( propertiesToTest.testRootBeanClass ) {
 				result = prime * result + ( rootBeanClass == null ? 0 : rootBeanClass.hashCode() );
 			}
@@ -424,15 +418,13 @@ public final class ConstraintViolationAssert {
 				return false;
 			}
 			ViolationExpectation other = (ViolationExpectation) obj;
-			if ( propertiesToTest.testConstraintType ) {
-				if ( constraintType == null ) {
-					if ( other.constraintType != null ) {
-						return false;
-					}
-				}
-				else if ( !constraintType.equals( other.constraintType ) ) {
+			if ( constraintType == null ) {
+				if ( other.constraintType != null ) {
 					return false;
 				}
+			}
+			else if ( !constraintType.equals( other.constraintType ) ) {
+				return false;
 			}
 			if ( propertiesToTest.testRootBeanClass ) {
 				if ( rootBeanClass == null ) {
@@ -480,8 +472,6 @@ public final class ConstraintViolationAssert {
 
 	private static class ViolationExpectationPropertiesToTest {
 
-		private boolean testConstraintType = false;
-
 		private boolean testRootBeanClass = false;
 
 		private boolean testMessage = false;
@@ -492,17 +482,11 @@ public final class ConstraintViolationAssert {
 
 		private static ViolationExpectationPropertiesToTest all() {
 			ViolationExpectationPropertiesToTest propertiesToTest = new ViolationExpectationPropertiesToTest()
-					.testConstraintType()
 					.testRootBeanClass()
 					.testMessage()
 					.testInvalidValue()
 					.testPropertyPath();
 			return propertiesToTest;
-		}
-
-		private ViolationExpectationPropertiesToTest testConstraintType() {
-			testConstraintType = true;
-			return this;
 		}
 
 		private ViolationExpectationPropertiesToTest testRootBeanClass() {
@@ -529,7 +513,6 @@ public final class ConstraintViolationAssert {
 		public int hashCode() {
 			final int prime = 31;
 			int result = 1;
-			result = prime * result + ( testConstraintType ? 1 : 0 );
 			result = prime * result + ( testRootBeanClass ? 1 : 0 );
 			result = prime * result + ( testMessage ? 1 : 0 );
 			result = prime * result + ( testInvalidValue ? 1 : 0 );
@@ -550,9 +533,6 @@ public final class ConstraintViolationAssert {
 			}
 
 			ViolationExpectationPropertiesToTest other = (ViolationExpectationPropertiesToTest) obj;
-			if ( testConstraintType != other.testConstraintType ) {
-				return false;
-			}
 			if ( testRootBeanClass != other.testRootBeanClass ) {
 				return false;
 			}


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/BVTCK-156

The core of the changes are there: https://github.com/beanvalidation/beanvalidation-tck/pull/117/files#diff-24ce6001f0f28ab8c04cf5ad206a97a3 .