### PR TITLE
BVTCK-178 Using new assert framework where possible

### DIFF
--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/application/method/MethodValidationRequirementTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/application/method/MethodValidationRequirementTest.java
@@ -6,10 +6,10 @@
  */
 package org.hibernate.beanvalidation.tck.tests.constraints.application.method;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintTypes;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 import static org.testng.Assert.assertNotNull;
 
 import java.lang.reflect.Constructor;
@@ -54,8 +54,9 @@ public class MethodValidationRequirementTest extends AbstractTCKTest {
 				parameterValues
 		);
 		assertNotNull( constraintViolations );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintTypes( constraintViolations, NotNull.class );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+		);
 	}
 
 	@Test
@@ -71,8 +72,9 @@ public class MethodValidationRequirementTest extends AbstractTCKTest {
 		);
 
 		assertNotNull( constraintViolations );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintTypes( constraintViolations, NotNull.class );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+		);
 	}
 
 	@Test
@@ -91,8 +93,9 @@ public class MethodValidationRequirementTest extends AbstractTCKTest {
 				parameterValues
 		);
 		assertNotNull( constraintViolations );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintTypes( constraintViolations, ConsistentDateParameters.class );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( ConsistentDateParameters.class )
+		);
 	}
 
 	@Test
@@ -110,8 +113,9 @@ public class MethodValidationRequirementTest extends AbstractTCKTest {
 				parameterValues
 		);
 		assertNotNull( constraintViolations );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintTypes( constraintViolations, ConsistentDateParameters.class );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( ConsistentDateParameters.class )
+		);
 	}
 
 	@Test
@@ -132,12 +136,9 @@ public class MethodValidationRequirementTest extends AbstractTCKTest {
 				method,
 				parameterValues
 		);
-		assertNotNull( constraintViolations );
-		assertNumberOfViolations( constraintViolations, 2 );
-		assertCorrectConstraintTypes(
-				constraintViolations,
-				NotNull.class,
-				ConsistentDateParameters.class
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class ),
+				violationOf( ConsistentDateParameters.class )
 		);
 	}
 
@@ -157,11 +158,9 @@ public class MethodValidationRequirementTest extends AbstractTCKTest {
 				parameterValues
 		);
 		assertNotNull( constraintViolations );
-		assertNumberOfViolations( constraintViolations, 2 );
-		assertCorrectConstraintTypes(
-				constraintViolations,
-				NotNull.class,
-				ConsistentDateParameters.class
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class ),
+				violationOf( ConsistentDateParameters.class )
 		);
 	}
 
@@ -178,8 +177,9 @@ public class MethodValidationRequirementTest extends AbstractTCKTest {
 				returnValue
 		);
 		assertNotNull( constraintViolations );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintTypes( constraintViolations, NotNull.class );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+		);
 	}
 
 	@Test
@@ -193,8 +193,9 @@ public class MethodValidationRequirementTest extends AbstractTCKTest {
 				returnValue
 		);
 		assertNotNull( constraintViolations );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintTypes( constraintViolations, OnlineCalendarService.class );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( OnlineCalendarService.class )
+		);
 	}
 
 	@Test
@@ -210,13 +211,13 @@ public class MethodValidationRequirementTest extends AbstractTCKTest {
 				parameterValues
 		);
 		assertNotNull( constraintViolations );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintTypes( constraintViolations, NotNull.class );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.method( "setUser" )
-						.parameter( "user", 0 )
-						.property( "name" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+				.withPropertyPath( pathWith()
+					   .method( "setUser" )
+					   .parameter( "user", 0 )
+					   .property( "name" )
+				)
 		);
 	}
 
@@ -231,13 +232,13 @@ public class MethodValidationRequirementTest extends AbstractTCKTest {
 				parameterValues
 		);
 		assertNotNull( constraintViolations );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintTypes( constraintViolations, NotNull.class );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.constructor( CalendarEvent.class )
-						.parameter( "user", 0 )
-						.property( "name" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+							   .constructor( CalendarEvent.class )
+							   .parameter( "user", 0 )
+							   .property( "name" )
+						)
 		);
 	}
 
@@ -254,13 +255,13 @@ public class MethodValidationRequirementTest extends AbstractTCKTest {
 				returnValue
 		);
 		assertNotNull( constraintViolations );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintTypes( constraintViolations, NotNull.class );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.method( "getUser" )
-						.returnValue()
-						.property( "name" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+							   .method( "getUser" )
+							   .returnValue()
+							   .property( "name" )
+						)
 		);
 	}
 
@@ -275,13 +276,13 @@ public class MethodValidationRequirementTest extends AbstractTCKTest {
 				returnValue
 		);
 		assertNotNull( constraintViolations );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintTypes( constraintViolations, NotNull.class );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.constructor( CalendarEvent.class )
-						.returnValue()
-						.property( "type" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+							   .constructor( CalendarEvent.class )
+							   .returnValue()
+							   .property( "type" )
+						)
 		);
 	}
 
@@ -298,7 +299,7 @@ public class MethodValidationRequirementTest extends AbstractTCKTest {
 				parameterValues
 		);
 		assertNotNull( constraintViolations );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	@Test
@@ -312,7 +313,7 @@ public class MethodValidationRequirementTest extends AbstractTCKTest {
 				parameterValues
 		);
 		assertNotNull( constraintViolations );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	@Test
@@ -328,7 +329,7 @@ public class MethodValidationRequirementTest extends AbstractTCKTest {
 				returnValue
 		);
 		assertNotNull( constraintViolations );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	@Test
@@ -344,14 +345,14 @@ public class MethodValidationRequirementTest extends AbstractTCKTest {
 				parameterValues
 		);
 		assertNotNull( constraintViolations );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintTypes( constraintViolations, NotNull.class );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.method( "setUser" )
-						.parameter( "user", 0 )
-						.property( "account" )
-						.property( "login" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+							   .method( "setUser" )
+							   .parameter( "user", 0 )
+							   .property( "account" )
+							   .property( "login" )
+						)
 		);
 	}
 
@@ -366,14 +367,14 @@ public class MethodValidationRequirementTest extends AbstractTCKTest {
 				parameterValues
 		);
 		assertNotNull( constraintViolations );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintTypes( constraintViolations, NotNull.class );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.constructor( CalendarEvent.class )
-						.parameter( "user", 0 )
-						.property( "account" )
-						.property( "login" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+							   .constructor( CalendarEvent.class )
+							   .parameter( "user", 0 )
+							   .property( "account" )
+							   .property( "login" )
+						)
 		);
 	}
 
@@ -390,14 +391,14 @@ public class MethodValidationRequirementTest extends AbstractTCKTest {
 				returnValue
 		);
 		assertNotNull( constraintViolations );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintTypes( constraintViolations, NotNull.class );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.method( "getUser" )
-						.returnValue()
-						.property( "account" )
-						.property( "login" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+							   .method( "getUser" )
+							   .returnValue()
+							   .property( "account" )
+							   .property( "login" )
+						)
 		);
 	}
 
@@ -412,14 +413,14 @@ public class MethodValidationRequirementTest extends AbstractTCKTest {
 				returnValue
 		);
 		assertNotNull( constraintViolations );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintTypes( constraintViolations, NotNull.class );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.constructor( CalendarEvent.class )
-						.returnValue()
-						.property( "user" )
-						.property( "name" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+							   .constructor( CalendarEvent.class )
+							   .returnValue()
+							   .property( "user" )
+							   .property( "name" )
+						)
 		);
 	}
 }

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/builtinconstraints/AssertConstraintsTests.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/builtinconstraints/AssertConstraintsTests.java
@@ -6,9 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.constraints.builtinconstraints;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertConstraintViolation;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.util.Set;
 
@@ -49,23 +49,27 @@ public class AssertConstraintsTests extends AbstractTCKTest {
 		AssertTrueDummyEntity dummy = new AssertTrueDummyEntity();
 
 		Set<ConstraintViolation<AssertTrueDummyEntity>> constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertConstraintViolation(
-				constraintViolations.iterator().next(), AssertTrueDummyEntity.class, false, pathWith().property( "primitiveBoolean" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( AssertTrue.class )
+						.withRootBeanClass( AssertTrueDummyEntity.class )
+						.withInvalidValue( false )
+						.withProperty( "primitiveBoolean" )
 		);
 
 		dummy.setPrimitiveBoolean( true );
 		dummy.setObjectBoolean( Boolean.FALSE );
 
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertConstraintViolation(
-				constraintViolations.iterator().next(), AssertTrueDummyEntity.class, Boolean.FALSE, pathWith().property( "objectBoolean" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( AssertTrue.class )
+						.withRootBeanClass( AssertTrueDummyEntity.class )
+						.withInvalidValue( Boolean.FALSE )
+						.withProperty( "objectBoolean" )
 		);
 
 		dummy.setObjectBoolean( Boolean.TRUE );
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	@Test
@@ -77,23 +81,27 @@ public class AssertConstraintsTests extends AbstractTCKTest {
 		dummy.setPrimitiveBoolean( true );
 
 		Set<ConstraintViolation<AssertFalseDummyEntity>> constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertConstraintViolation(
-				constraintViolations.iterator().next(), AssertFalseDummyEntity.class, true, pathWith().property( "primitiveBoolean" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( AssertFalse.class )
+						.withRootBeanClass( AssertFalseDummyEntity.class )
+						.withInvalidValue( true )
+						.withProperty( "primitiveBoolean" )
 		);
 
 		dummy.setPrimitiveBoolean( false );
 		dummy.setObjectBoolean( Boolean.TRUE );
 
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertConstraintViolation(
-				constraintViolations.iterator().next(), AssertFalseDummyEntity.class, Boolean.TRUE, pathWith().property(  "objectBoolean" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( AssertFalse.class )
+						.withRootBeanClass( AssertFalseDummyEntity.class )
+						.withInvalidValue( Boolean.TRUE )
+						.withProperty( "objectBoolean" )
 		);
 
 		dummy.setObjectBoolean( Boolean.FALSE );
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	private static class AssertTrueDummyEntity {

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/builtinconstraints/BuiltinValidatorOverrideTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/builtinconstraints/BuiltinValidatorOverrideTest.java
@@ -6,7 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.constraints.builtinconstraints;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.getInputStreamForPath;
 
 import java.io.InputStream;
@@ -52,11 +54,13 @@ public class BuiltinValidatorOverrideTest extends AbstractTCKTest {
 		Validator validator = config.buildValidatorFactory().getValidator();
 		DummyEntity dummy = new DummyEntity();
 		Set<ConstraintViolation<DummyEntity>> violations = validator.validate( dummy );
-		assertNumberOfViolations( violations, 0 );
+		assertNoViolations( violations );
 
 		dummy.dummyProperty = "foobar";
 		violations = validator.validate( dummy );
-		assertNumberOfViolations( violations, 1 );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+		);
 	}
 
 	private static class DummyEntity {

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/builtinconstraints/DecimalMinDecimalMaxConstraintsTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/builtinconstraints/DecimalMinDecimalMaxConstraintsTest.java
@@ -6,9 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.constraints.builtinconstraints;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -52,16 +52,11 @@ public class DecimalMinDecimalMaxConstraintsTest extends AbstractTCKTest {
 
 		Set<ConstraintViolation<DecimalMinDummyEntity>> constraintViolations = validator.validate( dummy );
 		// only the min constraints on the primitive values should fail. Object values re still null and should pass per spec
-		assertNumberOfViolations( constraintViolations, 4 );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "bytePrimitive" ),
-				pathWith()
-						.property( "intPrimitive" ),
-				pathWith()
-						.property( "longPrimitive" ),
-				pathWith()
-						.property( "shortPrimitive" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( DecimalMin.class ).withProperty( "bytePrimitive" ),
+				violationOf( DecimalMin.class ).withProperty( "intPrimitive" ),
+				violationOf( DecimalMin.class ).withProperty( "longPrimitive" ),
+				violationOf( DecimalMin.class ).withProperty( "shortPrimitive" )
 		);
 
 		dummy.intPrimitive = 101;
@@ -77,20 +72,13 @@ public class DecimalMinDecimalMaxConstraintsTest extends AbstractTCKTest {
 		dummy.bigInteger = BigInteger.valueOf( 100 );
 
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 6 );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "byteObject" ),
-				pathWith()
-						.property( "intObject" ),
-				pathWith()
-						.property( "longObject" ),
-				pathWith()
-						.property( "shortObject" ),
-				pathWith()
-						.property( "bigDecimal" ),
-				pathWith()
-						.property( "bigInteger" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( DecimalMin.class ).withProperty( "byteObject" ),
+				violationOf( DecimalMin.class ).withProperty( "intObject" ),
+				violationOf( DecimalMin.class ).withProperty( "longObject" ),
+				violationOf( DecimalMin.class ).withProperty( "shortObject" ),
+				violationOf( DecimalMin.class ).withProperty( "bigDecimal" ),
+				violationOf( DecimalMin.class ).withProperty( "bigInteger" )
 		);
 
 		dummy.intObject = Integer.valueOf( "101" );
@@ -101,7 +89,7 @@ public class DecimalMinDecimalMaxConstraintsTest extends AbstractTCKTest {
 		dummy.bigInteger = BigInteger.valueOf( 101 );
 
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	@Test
@@ -118,16 +106,11 @@ public class DecimalMinDecimalMaxConstraintsTest extends AbstractTCKTest {
 
 		Set<ConstraintViolation<DecimalMaxDummyEntity>> constraintViolations = validator.validate( dummy );
 		// only the max constraints on the primitive values should fail. Object values re still null and should pass per spec
-		assertNumberOfViolations( constraintViolations, 4 );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "bytePrimitive" ),
-				pathWith()
-						.property( "intPrimitive" ),
-				pathWith()
-						.property( "longPrimitive" ),
-				pathWith()
-						.property( "shortPrimitive" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( DecimalMax.class ).withProperty( "bytePrimitive" ),
+				violationOf( DecimalMax.class ).withProperty( "intPrimitive" ),
+				violationOf( DecimalMax.class ).withProperty( "longPrimitive" ),
+				violationOf( DecimalMax.class ).withProperty( "shortPrimitive" )
 		);
 
 
@@ -144,20 +127,13 @@ public class DecimalMinDecimalMaxConstraintsTest extends AbstractTCKTest {
 		dummy.bigInteger = BigInteger.valueOf( 102 );
 
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 6 );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "byteObject" ),
-				pathWith()
-						.property( "intObject" ),
-				pathWith()
-						.property( "longObject" ),
-				pathWith()
-						.property( "shortObject" ),
-				pathWith()
-						.property( "bigDecimal" ),
-				pathWith()
-						.property( "bigInteger" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( DecimalMax.class ).withProperty( "byteObject" ),
+				violationOf( DecimalMax.class ).withProperty( "intObject" ),
+				violationOf( DecimalMax.class ).withProperty( "longObject" ),
+				violationOf( DecimalMax.class ).withProperty( "shortObject" ),
+				violationOf( DecimalMax.class ).withProperty( "bigDecimal" ),
+				violationOf( DecimalMax.class ).withProperty( "bigInteger" )
 		);
 
 		dummy.intObject = Integer.valueOf( "101" );
@@ -168,7 +144,7 @@ public class DecimalMinDecimalMaxConstraintsTest extends AbstractTCKTest {
 		dummy.bigInteger = BigInteger.valueOf( 100 );
 
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	private static class DecimalMaxDummyEntity {

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/builtinconstraints/DigitsConstraintTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/builtinconstraints/DigitsConstraintTest.java
@@ -6,9 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.constraints.builtinconstraints;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -56,18 +56,12 @@ public class DigitsConstraintTest extends AbstractTCKTest {
 
 		Set<ConstraintViolation<DigitsDummyEntity>> constraintViolations = validator.validate( dummy );
 		// only the max constraints on the primitive values should fail. Object values re still null and should pass per spec
-		assertNumberOfViolations( constraintViolations, 4 );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "bytePrimitive" ),
-				pathWith()
-						.property( "intPrimitive" ),
-				pathWith()
-						.property( "longPrimitive" ),
-				pathWith()
-						.property( "shortPrimitive" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Digits.class ).withProperty( "bytePrimitive" ),
+				violationOf( Digits.class ).withProperty( "intPrimitive" ),
+				violationOf( Digits.class ).withProperty( "longPrimitive" ),
+				violationOf( Digits.class ).withProperty( "shortPrimitive" )
 		);
-
 
 		dummy.intPrimitive = 1;
 		dummy.longPrimitive = 1;
@@ -82,20 +76,13 @@ public class DigitsConstraintTest extends AbstractTCKTest {
 		dummy.bigInteger = BigInteger.valueOf( 102 );
 
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 6 );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "byteObject" ),
-				pathWith()
-						.property( "intObject" ),
-				pathWith()
-						.property( "longObject" ),
-				pathWith()
-						.property( "shortObject" ),
-				pathWith()
-						.property( "bigDecimal" ),
-				pathWith()
-						.property( "bigInteger" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Digits.class ).withProperty( "byteObject" ),
+				violationOf( Digits.class ).withProperty( "intObject" ),
+				violationOf( Digits.class ).withProperty( "longObject" ),
+				violationOf( Digits.class ).withProperty( "shortObject" ),
+				violationOf( Digits.class ).withProperty( "bigDecimal" ),
+				violationOf( Digits.class ).withProperty( "bigInteger" )
 		);
 
 		dummy.intObject = Integer.valueOf( "1" );
@@ -106,7 +93,7 @@ public class DigitsConstraintTest extends AbstractTCKTest {
 		dummy.bigInteger = BigInteger.valueOf( 5 );
 
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	private static class DigitsDummyEntity {

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/builtinconstraints/FuturePastConstraintsTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/builtinconstraints/FuturePastConstraintsTest.java
@@ -6,9 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.constraints.builtinconstraints;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -75,7 +75,7 @@ public class FuturePastConstraintsTest extends AbstractTCKTest {
 		PastDummyEntity dummy = new PastDummyEntity();
 
 		Set<ConstraintViolation<PastDummyEntity>> constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		ZonedDateTime reference = ZonedDateTime.now( TZ_BERLIN );
 
@@ -83,41 +83,27 @@ public class FuturePastConstraintsTest extends AbstractTCKTest {
 		dummy = new PastDummyEntity( future );
 
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 13 );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "date" ),
-				pathWith()
-						.property( "calendar" ),
-				pathWith()
-						.property( "instant" ),
-				pathWith()
-						.property( "hijrahDate" ),
-				pathWith()
-						.property( "japaneseDate" ),
-				pathWith()
-						.property( "localDate" ),
-				pathWith()
-						.property( "localDateTime" ),
-				pathWith()
-						.property( "minguoDate" ),
-				pathWith()
-						.property( "offsetDateTime" ),
-				pathWith()
-						.property( "thaiBuddhistDate" ),
-				pathWith()
-						.property( "year" ),
-				pathWith()
-						.property( "yearMonth" ),
-				pathWith()
-						.property( "zonedDateTime" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Past.class ).withProperty( "date" ),
+				violationOf( Past.class ).withProperty( "calendar" ),
+				violationOf( Past.class ).withProperty( "instant" ),
+				violationOf( Past.class ).withProperty( "hijrahDate" ),
+				violationOf( Past.class ).withProperty( "japaneseDate" ),
+				violationOf( Past.class ).withProperty( "localDate" ),
+				violationOf( Past.class ).withProperty( "localDateTime" ),
+				violationOf( Past.class ).withProperty( "minguoDate" ),
+				violationOf( Past.class ).withProperty( "offsetDateTime" ),
+				violationOf( Past.class ).withProperty( "thaiBuddhistDate" ),
+				violationOf( Past.class ).withProperty( "year" ),
+				violationOf( Past.class ).withProperty( "yearMonth" ),
+				violationOf( Past.class ).withProperty( "zonedDateTime" )
 		);
 
 		ZonedDateTime past = reference.minusYears( 1 ).minusMonths( 1 ).minusHours( 1 );
 		dummy = new PastDummyEntity( past );
 
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	@Test
@@ -137,27 +123,23 @@ public class FuturePastConstraintsTest extends AbstractTCKTest {
 		PastRelativePartialDummyEntity dummy = new PastRelativePartialDummyEntity();
 
 		Set<ConstraintViolation<PastRelativePartialDummyEntity>> constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		ZonedDateTime future = reference.plusMonths( 1 ).plusHours( 1 );
 		dummy = new PastRelativePartialDummyEntity( future );
 
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 3 );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "localTime" ),
-				pathWith()
-						.property( "monthDay" ),
-				pathWith()
-						.property( "offsetTime" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Past.class ).withProperty( "localTime" ),
+				violationOf( Past.class ).withProperty( "monthDay" ),
+				violationOf( Past.class ).withProperty( "offsetTime" )
 		);
 
 		ZonedDateTime past = reference.minusMonths( 1 ).minusHours( 1 );
 		dummy = new PastRelativePartialDummyEntity( past );
 
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	@Test
@@ -168,7 +150,7 @@ public class FuturePastConstraintsTest extends AbstractTCKTest {
 		FutureDummyEntity dummy = new FutureDummyEntity();
 
 		Set<ConstraintViolation<FutureDummyEntity>> constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		ZonedDateTime reference = ZonedDateTime.now( TZ_BERLIN );
 
@@ -176,41 +158,27 @@ public class FuturePastConstraintsTest extends AbstractTCKTest {
 		dummy = new FutureDummyEntity( past );
 
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 13 );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "date" ),
-				pathWith()
-						.property( "calendar" ),
-				pathWith()
-						.property( "instant" ),
-				pathWith()
-						.property( "hijrahDate" ),
-				pathWith()
-						.property( "japaneseDate" ),
-				pathWith()
-						.property( "localDate" ),
-				pathWith()
-						.property( "localDateTime" ),
-				pathWith()
-						.property( "minguoDate" ),
-				pathWith()
-						.property( "offsetDateTime" ),
-				pathWith()
-						.property( "thaiBuddhistDate" ),
-				pathWith()
-						.property( "year" ),
-				pathWith()
-						.property( "yearMonth" ),
-				pathWith()
-						.property( "zonedDateTime" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Future.class ).withProperty( "date" ),
+				violationOf( Future.class ).withProperty( "calendar" ),
+				violationOf( Future.class ).withProperty( "instant" ),
+				violationOf( Future.class ).withProperty( "hijrahDate" ),
+				violationOf( Future.class ).withProperty( "japaneseDate" ),
+				violationOf( Future.class ).withProperty( "localDate" ),
+				violationOf( Future.class ).withProperty( "localDateTime" ),
+				violationOf( Future.class ).withProperty( "minguoDate" ),
+				violationOf( Future.class ).withProperty( "offsetDateTime" ),
+				violationOf( Future.class ).withProperty( "thaiBuddhistDate" ),
+				violationOf( Future.class ).withProperty( "year" ),
+				violationOf( Future.class ).withProperty( "yearMonth" ),
+				violationOf( Future.class ).withProperty( "zonedDateTime" )
 		);
 
 		ZonedDateTime future = reference.plusYears( 1 ).plusMonths( 1 ).plusHours( 1 );
 		dummy = new FutureDummyEntity( future );
 
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	@Test
@@ -230,27 +198,23 @@ public class FuturePastConstraintsTest extends AbstractTCKTest {
 		FutureRelativePartialDummyEntity dummy = new FutureRelativePartialDummyEntity();
 
 		Set<ConstraintViolation<FutureRelativePartialDummyEntity>> constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		ZonedDateTime past = reference.minusMonths( 1 ).minusHours( 1 );
 		dummy = new FutureRelativePartialDummyEntity( past );
 
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 3 );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "localTime" ),
-				pathWith()
-						.property( "monthDay" ),
-				pathWith()
-						.property( "offsetTime" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Future.class ).withProperty( "localTime" ),
+				violationOf( Future.class ).withProperty( "monthDay" ),
+				violationOf( Future.class ).withProperty( "offsetTime" )
 		);
 
 		ZonedDateTime future = reference.plusMonths( 1 ).plusHours( 1 );
 		dummy = new FutureRelativePartialDummyEntity( future );
 
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	@Test
@@ -266,80 +230,52 @@ public class FuturePastConstraintsTest extends AbstractTCKTest {
 		PastDummyEntity pastDummy = new PastDummyEntity( reference );
 
 		Set<ConstraintViolation<PastDummyEntity>> pastConstraintViolations = validator.validate( pastDummy );
-		assertNumberOfViolations( pastConstraintViolations, 13 );
-		assertThat( pastConstraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "date" ),
-				pathWith()
-						.property( "calendar" ),
-				pathWith()
-						.property( "instant" ),
-				pathWith()
-						.property( "hijrahDate" ),
-				pathWith()
-						.property( "japaneseDate" ),
-				pathWith()
-						.property( "localDate" ),
-				pathWith()
-						.property( "localDateTime" ),
-				pathWith()
-						.property( "minguoDate" ),
-				pathWith()
-						.property( "offsetDateTime" ),
-				pathWith()
-						.property( "thaiBuddhistDate" ),
-				pathWith()
-						.property( "year" ),
-				pathWith()
-						.property( "yearMonth" ),
-				pathWith()
-						.property( "zonedDateTime" )
+		assertThat( pastConstraintViolations ).containsOnlyViolations(
+				violationOf( Past.class ).withProperty( "date" ),
+				violationOf( Past.class ).withProperty( "calendar" ),
+				violationOf( Past.class ).withProperty( "instant" ),
+				violationOf( Past.class ).withProperty( "hijrahDate" ),
+				violationOf( Past.class ).withProperty( "japaneseDate" ),
+				violationOf( Past.class ).withProperty( "localDate" ),
+				violationOf( Past.class ).withProperty( "localDateTime" ),
+				violationOf( Past.class ).withProperty( "minguoDate" ),
+				violationOf( Past.class ).withProperty( "offsetDateTime" ),
+				violationOf( Past.class ).withProperty( "thaiBuddhistDate" ),
+				violationOf( Past.class ).withProperty( "year" ),
+				violationOf( Past.class ).withProperty( "yearMonth" ),
+				violationOf( Past.class ).withProperty( "zonedDateTime" )
 		);
 
 		PastOrPresentDummyEntity pastOrPresentDummy = new PastOrPresentDummyEntity();
 		Set<ConstraintViolation<PastOrPresentDummyEntity>> pastOrPresentConstraintViolations = validator.validate( pastOrPresentDummy );
-		assertNumberOfViolations( pastOrPresentConstraintViolations, 0 );
+		assertNoViolations( pastOrPresentConstraintViolations );
 
 		pastOrPresentDummy = new PastOrPresentDummyEntity( reference );
 		pastOrPresentConstraintViolations = validator.validate( pastOrPresentDummy );
-		assertNumberOfViolations( pastOrPresentConstraintViolations, 0 );
+		assertNoViolations( pastOrPresentConstraintViolations );
 
 		ZonedDateTime pastDate = ZonedDateTime.of( 2015, 5, 5, 13, 14, 0, 0, TZ_BERLIN );
 		pastOrPresentDummy = new PastOrPresentDummyEntity( pastDate );
 		pastOrPresentConstraintViolations = validator.validate( pastOrPresentDummy );
-		assertNumberOfViolations( pastOrPresentConstraintViolations, 0 );
+		assertNoViolations( pastOrPresentConstraintViolations );
 
 		ZonedDateTime futureDate = ZonedDateTime.of( 2017, 7, 7, 15, 32, 0, 0, TZ_BERLIN );
 		pastOrPresentDummy = new PastOrPresentDummyEntity( futureDate );
 		pastOrPresentConstraintViolations = validator.validate( pastOrPresentDummy );
-		assertNumberOfViolations( pastConstraintViolations, 13 );
-		assertThat( pastConstraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "date" ),
-				pathWith()
-						.property( "calendar" ),
-				pathWith()
-						.property( "instant" ),
-				pathWith()
-						.property( "hijrahDate" ),
-				pathWith()
-						.property( "japaneseDate" ),
-				pathWith()
-						.property( "localDate" ),
-				pathWith()
-						.property( "localDateTime" ),
-				pathWith()
-						.property( "minguoDate" ),
-				pathWith()
-						.property( "offsetDateTime" ),
-				pathWith()
-						.property( "thaiBuddhistDate" ),
-				pathWith()
-						.property( "year" ),
-				pathWith()
-						.property( "yearMonth" ),
-				pathWith()
-						.property( "zonedDateTime" )
+		assertThat( pastOrPresentConstraintViolations ).containsOnlyViolations(
+				violationOf( PastOrPresent.class ).withProperty( "date" ),
+				violationOf( PastOrPresent.class ).withProperty( "calendar" ),
+				violationOf( PastOrPresent.class ).withProperty( "instant" ),
+				violationOf( PastOrPresent.class ).withProperty( "hijrahDate" ),
+				violationOf( PastOrPresent.class ).withProperty( "japaneseDate" ),
+				violationOf( PastOrPresent.class ).withProperty( "localDate" ),
+				violationOf( PastOrPresent.class ).withProperty( "localDateTime" ),
+				violationOf( PastOrPresent.class ).withProperty( "minguoDate" ),
+				violationOf( PastOrPresent.class ).withProperty( "offsetDateTime" ),
+				violationOf( PastOrPresent.class ).withProperty( "thaiBuddhistDate" ),
+				violationOf( PastOrPresent.class ).withProperty( "year" ),
+				violationOf( PastOrPresent.class ).withProperty( "yearMonth" ),
+				violationOf( PastOrPresent.class ).withProperty( "zonedDateTime" )
 		);
 	}
 
@@ -356,40 +292,32 @@ public class FuturePastConstraintsTest extends AbstractTCKTest {
 		PastRelativePartialDummyEntity pastDummy = new PastRelativePartialDummyEntity( reference );
 
 		Set<ConstraintViolation<PastRelativePartialDummyEntity>> pastConstraintViolations = validator.validate( pastDummy );
-		assertNumberOfViolations( pastConstraintViolations, 3 );
-		assertThat( pastConstraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "localTime" ),
-				pathWith()
-						.property( "monthDay" ),
-				pathWith()
-						.property( "offsetTime" )
+		assertThat( pastConstraintViolations ).containsOnlyViolations(
+				violationOf( Past.class ).withProperty( "localTime" ),
+				violationOf( Past.class ).withProperty( "monthDay" ),
+				violationOf( Past.class ).withProperty( "offsetTime" )
 		);
 
 		PastOrPresentRelativePartialDummyEntity pastOrPresentDummy = new PastOrPresentRelativePartialDummyEntity();
 		Set<ConstraintViolation<PastOrPresentRelativePartialDummyEntity>> pastOrPresentConstraintViolations = validator.validate( pastOrPresentDummy );
-		assertNumberOfViolations( pastOrPresentConstraintViolations, 0 );
+		assertNoViolations( pastOrPresentConstraintViolations );
 
 		pastOrPresentDummy = new PastOrPresentRelativePartialDummyEntity( reference );
 		pastOrPresentConstraintViolations = validator.validate( pastOrPresentDummy );
-		assertNumberOfViolations( pastOrPresentConstraintViolations, 0 );
+		assertNoViolations( pastOrPresentConstraintViolations );
 
 		ZonedDateTime pastDate = ZonedDateTime.of( 2015, 5, 5, 13, 14, 0, 0, TZ_BERLIN );
 		pastOrPresentDummy = new PastOrPresentRelativePartialDummyEntity( pastDate );
 		pastOrPresentConstraintViolations = validator.validate( pastOrPresentDummy );
-		assertNumberOfViolations( pastOrPresentConstraintViolations, 0 );
+		assertNoViolations( pastOrPresentConstraintViolations );
 
 		ZonedDateTime futureDate = ZonedDateTime.of( 2017, 7, 7, 15, 32, 0, 0, TZ_BERLIN );
 		pastOrPresentDummy = new PastOrPresentRelativePartialDummyEntity( futureDate );
 		pastOrPresentConstraintViolations = validator.validate( pastOrPresentDummy );
-		assertNumberOfViolations( pastOrPresentConstraintViolations, 3 );
-		assertThat( pastOrPresentConstraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "localTime" ),
-				pathWith()
-						.property( "monthDay" ),
-				pathWith()
-						.property( "offsetTime" )
+		assertThat( pastOrPresentConstraintViolations ).containsOnlyViolations(
+				violationOf( PastOrPresent.class ).withProperty( "localTime" ),
+				violationOf( PastOrPresent.class ).withProperty( "monthDay" ),
+				violationOf( PastOrPresent.class ).withProperty( "offsetTime" )
 		);
 	}
 
@@ -406,80 +334,52 @@ public class FuturePastConstraintsTest extends AbstractTCKTest {
 		FutureDummyEntity futureDummy = new FutureDummyEntity( reference );
 
 		Set<ConstraintViolation<FutureDummyEntity>> futureConstraintViolations = validator.validate( futureDummy );
-		assertNumberOfViolations( futureConstraintViolations, 13 );
-		assertThat( futureConstraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "date" ),
-				pathWith()
-						.property( "calendar" ),
-				pathWith()
-						.property( "instant" ),
-				pathWith()
-						.property( "hijrahDate" ),
-				pathWith()
-						.property( "japaneseDate" ),
-				pathWith()
-						.property( "localDate" ),
-				pathWith()
-						.property( "localDateTime" ),
-				pathWith()
-						.property( "minguoDate" ),
-				pathWith()
-						.property( "offsetDateTime" ),
-				pathWith()
-						.property( "thaiBuddhistDate" ),
-				pathWith()
-						.property( "year" ),
-				pathWith()
-						.property( "yearMonth" ),
-				pathWith()
-						.property( "zonedDateTime" )
+		assertThat( futureConstraintViolations ).containsOnlyViolations(
+				violationOf( Future.class ).withProperty( "date" ),
+				violationOf( Future.class ).withProperty( "calendar" ),
+				violationOf( Future.class ).withProperty( "instant" ),
+				violationOf( Future.class ).withProperty( "hijrahDate" ),
+				violationOf( Future.class ).withProperty( "japaneseDate" ),
+				violationOf( Future.class ).withProperty( "localDate" ),
+				violationOf( Future.class ).withProperty( "localDateTime" ),
+				violationOf( Future.class ).withProperty( "minguoDate" ),
+				violationOf( Future.class ).withProperty( "offsetDateTime" ),
+				violationOf( Future.class ).withProperty( "thaiBuddhistDate" ),
+				violationOf( Future.class ).withProperty( "year" ),
+				violationOf( Future.class ).withProperty( "yearMonth" ),
+				violationOf( Future.class ).withProperty( "zonedDateTime" )
 		);
 
 		FutureOrPresentDummyEntity futureOrPresentDummy = new FutureOrPresentDummyEntity();
 		Set<ConstraintViolation<FutureOrPresentDummyEntity>> futureOrPresentConstraintViolations = validator.validate( futureOrPresentDummy );
-		assertNumberOfViolations( futureOrPresentConstraintViolations, 0 );
+		assertNoViolations( futureOrPresentConstraintViolations );
 
 		futureOrPresentDummy = new FutureOrPresentDummyEntity( reference );
 		futureOrPresentConstraintViolations = validator.validate( futureOrPresentDummy );
-		assertNumberOfViolations( futureOrPresentConstraintViolations, 0 );
+		assertNoViolations( futureOrPresentConstraintViolations );
 
 		ZonedDateTime futureDate = ZonedDateTime.of( 2017, 7, 7, 15, 32, 0, 0, TZ_BERLIN );
 		futureOrPresentDummy = new FutureOrPresentDummyEntity( futureDate );
 		futureOrPresentConstraintViolations = validator.validate( futureOrPresentDummy );
-		assertNumberOfViolations( futureOrPresentConstraintViolations, 0 );
+		assertNoViolations( futureOrPresentConstraintViolations );
 
 		ZonedDateTime pastDate = ZonedDateTime.of( 2015, 4, 3, 12, 20, 0, 0, TZ_BERLIN );
 		futureOrPresentDummy = new FutureOrPresentDummyEntity( pastDate );
 		futureOrPresentConstraintViolations = validator.validate( futureOrPresentDummy );
-		assertNumberOfViolations( futureConstraintViolations, 13 );
-		assertThat( futureConstraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "date" ),
-				pathWith()
-						.property( "calendar" ),
-				pathWith()
-						.property( "instant" ),
-				pathWith()
-						.property( "hijrahDate" ),
-				pathWith()
-						.property( "japaneseDate" ),
-				pathWith()
-						.property( "localDate" ),
-				pathWith()
-						.property( "localDateTime" ),
-				pathWith()
-						.property( "minguoDate" ),
-				pathWith()
-						.property( "offsetDateTime" ),
-				pathWith()
-						.property( "thaiBuddhistDate" ),
-				pathWith()
-						.property( "year" ),
-				pathWith()
-						.property( "yearMonth" ),
-				pathWith()
-						.property( "zonedDateTime" )
+		assertThat( futureOrPresentConstraintViolations ).containsOnlyViolations(
+				violationOf( FutureOrPresent.class ).withProperty( "date" ),
+				violationOf( FutureOrPresent.class ).withProperty( "calendar" ),
+				violationOf( FutureOrPresent.class ).withProperty( "instant" ),
+				violationOf( FutureOrPresent.class ).withProperty( "hijrahDate" ),
+				violationOf( FutureOrPresent.class ).withProperty( "japaneseDate" ),
+				violationOf( FutureOrPresent.class ).withProperty( "localDate" ),
+				violationOf( FutureOrPresent.class ).withProperty( "localDateTime" ),
+				violationOf( FutureOrPresent.class ).withProperty( "minguoDate" ),
+				violationOf( FutureOrPresent.class ).withProperty( "offsetDateTime" ),
+				violationOf( FutureOrPresent.class ).withProperty( "thaiBuddhistDate" ),
+				violationOf( FutureOrPresent.class ).withProperty( "year" ),
+				violationOf( FutureOrPresent.class ).withProperty( "yearMonth" ),
+				violationOf( FutureOrPresent.class ).withProperty( "zonedDateTime" )
 		);
 	}
 
@@ -496,40 +396,32 @@ public class FuturePastConstraintsTest extends AbstractTCKTest {
 		FutureRelativePartialDummyEntity futureDummy = new FutureRelativePartialDummyEntity( reference );
 
 		Set<ConstraintViolation<FutureRelativePartialDummyEntity>> futureConstraintViolations = validator.validate( futureDummy );
-		assertNumberOfViolations( futureConstraintViolations, 3 );
-		assertThat( futureConstraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "localTime" ),
-				pathWith()
-						.property( "monthDay" ),
-				pathWith()
-						.property( "offsetTime" )
+		assertThat( futureConstraintViolations ).containsOnlyViolations(
+				violationOf( Future.class ).withProperty( "localTime" ),
+				violationOf( Future.class ).withProperty( "monthDay" ),
+				violationOf( Future.class ).withProperty( "offsetTime" )
 		);
 
 		FutureOrPresentRelativePartialDummyEntity futureOrPresentDummy = new FutureOrPresentRelativePartialDummyEntity();
 		Set<ConstraintViolation<FutureOrPresentRelativePartialDummyEntity>> futureOrPresentConstraintViolations = validator.validate( futureOrPresentDummy );
-		assertNumberOfViolations( futureOrPresentConstraintViolations, 0 );
+		assertNoViolations( futureOrPresentConstraintViolations );
 
 		futureOrPresentDummy = new FutureOrPresentRelativePartialDummyEntity( reference );
 		futureOrPresentConstraintViolations = validator.validate( futureOrPresentDummy );
-		assertNumberOfViolations( futureOrPresentConstraintViolations, 0 );
+		assertNoViolations( futureOrPresentConstraintViolations );
 
 		ZonedDateTime futureDate = ZonedDateTime.of( 2017, 7, 7, 15, 32, 0, 0, TZ_BERLIN );
 		futureOrPresentDummy = new FutureOrPresentRelativePartialDummyEntity( futureDate );
 		futureOrPresentConstraintViolations = validator.validate( futureOrPresentDummy );
-		assertNumberOfViolations( futureOrPresentConstraintViolations, 0 );
+		assertNoViolations( futureOrPresentConstraintViolations );
 
 		ZonedDateTime pastDate = ZonedDateTime.of( 2015, 4, 3, 12, 20, 0, 0, TZ_BERLIN );
 		futureOrPresentDummy = new FutureOrPresentRelativePartialDummyEntity( pastDate );
 		futureOrPresentConstraintViolations = validator.validate( futureOrPresentDummy );
-		assertNumberOfViolations( futureOrPresentConstraintViolations, 3 );
-		assertThat( futureOrPresentConstraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "localTime" ),
-				pathWith()
-						.property( "monthDay" ),
-				pathWith()
-						.property( "offsetTime" )
+		assertThat( futureOrPresentConstraintViolations ).containsOnlyViolations(
+				violationOf( FutureOrPresent.class ).withProperty( "localTime" ),
+				violationOf( FutureOrPresent.class ).withProperty( "monthDay" ),
+				violationOf( FutureOrPresent.class ).withProperty( "offsetTime" )
 		);
 	}
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/builtinconstraints/MinMaxConstraintsTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/builtinconstraints/MinMaxConstraintsTest.java
@@ -6,9 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.constraints.builtinconstraints;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -52,16 +52,11 @@ public class MinMaxConstraintsTest extends AbstractTCKTest {
 
 		Set<ConstraintViolation<MinDummyEntity>> constraintViolations = validator.validate( dummy );
 		// only the min constraints on the primitive values should fail. Object values re still null and should pass per spec
-		assertNumberOfViolations( constraintViolations, 4 );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "bytePrimitive" ),
-				pathWith()
-						.property( "intPrimitive" ),
-				pathWith()
-						.property( "longPrimitive" ),
-				pathWith()
-						.property( "shortPrimitive" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Min.class ).withProperty( "bytePrimitive" ),
+				violationOf( Min.class ).withProperty( "intPrimitive" ),
+				violationOf( Min.class ).withProperty( "longPrimitive" ),
+				violationOf( Min.class ).withProperty( "shortPrimitive" )
 		);
 
 
@@ -78,20 +73,13 @@ public class MinMaxConstraintsTest extends AbstractTCKTest {
 		dummy.bigInteger = BigInteger.valueOf( 100 );
 
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 6 );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "byteObject" ),
-				pathWith()
-						.property( "intObject" ),
-				pathWith()
-						.property( "longObject" ),
-				pathWith()
-						.property( "shortObject" ),
-				pathWith()
-						.property( "bigDecimal" ),
-				pathWith()
-						.property( "bigInteger" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Min.class ).withProperty( "byteObject" ),
+				violationOf( Min.class ).withProperty( "intObject" ),
+				violationOf( Min.class ).withProperty( "longObject" ),
+				violationOf( Min.class ).withProperty( "shortObject" ),
+				violationOf( Min.class ).withProperty( "bigDecimal" ),
+				violationOf( Min.class ).withProperty( "bigInteger" )
 		);
 
 		dummy.intObject = Integer.valueOf( "101" );
@@ -102,7 +90,7 @@ public class MinMaxConstraintsTest extends AbstractTCKTest {
 		dummy.bigInteger = BigInteger.valueOf( 101 );
 
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	@Test
@@ -119,16 +107,11 @@ public class MinMaxConstraintsTest extends AbstractTCKTest {
 
 		Set<ConstraintViolation<MaxDummyEntity>> constraintViolations = validator.validate( dummy );
 		// only the max constraints on the primitive values should fail. Object values re still null and should pass per spec
-		assertNumberOfViolations( constraintViolations, 4 );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "bytePrimitive" ),
-				pathWith()
-						.property( "intPrimitive" ),
-				pathWith()
-						.property( "longPrimitive" ),
-				pathWith()
-						.property( "shortPrimitive" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Max.class ).withProperty( "bytePrimitive" ),
+				violationOf( Max.class ).withProperty( "intPrimitive" ),
+				violationOf( Max.class ).withProperty( "longPrimitive" ),
+				violationOf( Max.class ).withProperty( "shortPrimitive" )
 		);
 
 
@@ -145,20 +128,13 @@ public class MinMaxConstraintsTest extends AbstractTCKTest {
 		dummy.bigInteger = BigInteger.valueOf( 102 );
 
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 6 );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "byteObject" ),
-				pathWith()
-						.property( "intObject" ),
-				pathWith()
-						.property( "longObject" ),
-				pathWith()
-						.property( "shortObject" ),
-				pathWith()
-						.property( "bigDecimal" ),
-				pathWith()
-						.property( "bigInteger" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Max.class ).withProperty( "byteObject" ),
+				violationOf( Max.class ).withProperty( "intObject" ),
+				violationOf( Max.class ).withProperty( "longObject" ),
+				violationOf( Max.class ).withProperty( "shortObject" ),
+				violationOf( Max.class ).withProperty( "bigDecimal" ),
+				violationOf( Max.class ).withProperty( "bigInteger" )
 		);
 
 		dummy.intObject = Integer.valueOf( "101" );
@@ -169,7 +145,7 @@ public class MinMaxConstraintsTest extends AbstractTCKTest {
 		dummy.bigInteger = BigInteger.valueOf( 100 );
 
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	private static class MinDummyEntity {

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/builtinconstraints/NegativePositiveConstraintsTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/builtinconstraints/NegativePositiveConstraintsTest.java
@@ -6,9 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.constraints.builtinconstraints;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -53,19 +53,13 @@ public class NegativePositiveConstraintsTest extends AbstractTCKTest {
 		NegativeEntity dummy = new NegativeEntity();
 
 		Set<ConstraintViolation<NegativeEntity>> constraintViolations = validator.validate( dummy );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "bytePrimitive" ),
-				pathWith()
-						.property( "intPrimitive" ),
-				pathWith()
-						.property( "longPrimitive" ),
-				pathWith()
-						.property( "shortPrimitive" ),
-				pathWith()
-						.property( "doublePrimitive" ),
-				pathWith()
-						.property( "floatPrimitive" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Negative.class ).withProperty( "bytePrimitive" ),
+				violationOf( Negative.class ).withProperty( "intPrimitive" ),
+				violationOf( Negative.class ).withProperty( "longPrimitive" ),
+				violationOf( Negative.class ).withProperty( "shortPrimitive" ),
+				violationOf( Negative.class ).withProperty( "doublePrimitive" ),
+				violationOf( Negative.class ).withProperty( "floatPrimitive" )
 		);
 
 		dummy.intPrimitive = 101;
@@ -84,35 +78,21 @@ public class NegativePositiveConstraintsTest extends AbstractTCKTest {
 		dummy.bigInteger = BigInteger.valueOf( 100 );
 
 		constraintViolations = validator.validate( dummy );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "bytePrimitive" ),
-				pathWith()
-						.property( "intPrimitive" ),
-				pathWith()
-						.property( "longPrimitive" ),
-				pathWith()
-						.property( "shortPrimitive" ),
-				pathWith()
-						.property( "doublePrimitive" ),
-				pathWith()
-						.property( "floatPrimitive" ),
-				pathWith()
-						.property( "byteObject" ),
-				pathWith()
-						.property( "intObject" ),
-				pathWith()
-						.property( "longObject" ),
-				pathWith()
-						.property( "shortObject" ),
-				pathWith()
-						.property( "doubleObject" ),
-				pathWith()
-						.property( "floatObject" ),
-				pathWith()
-						.property( "bigDecimal" ),
-				pathWith()
-						.property( "bigInteger" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Negative.class ).withProperty( "bytePrimitive" ),
+				violationOf( Negative.class ).withProperty( "intPrimitive" ),
+				violationOf( Negative.class ).withProperty( "longPrimitive" ),
+				violationOf( Negative.class ).withProperty( "shortPrimitive" ),
+				violationOf( Negative.class ).withProperty( "doublePrimitive" ),
+				violationOf( Negative.class ).withProperty( "floatPrimitive" ),
+				violationOf( Negative.class ).withProperty( "byteObject" ),
+				violationOf( Negative.class ).withProperty( "intObject" ),
+				violationOf( Negative.class ).withProperty( "longObject" ),
+				violationOf( Negative.class ).withProperty( "shortObject" ),
+				violationOf( Negative.class ).withProperty( "doubleObject" ),
+				violationOf( Negative.class ).withProperty( "floatObject" ),
+				violationOf( Negative.class ).withProperty( "bigDecimal" ),
+				violationOf( Negative.class ).withProperty( "bigInteger" )
 		);
 
 		dummy.intPrimitive = 0;
@@ -132,35 +112,21 @@ public class NegativePositiveConstraintsTest extends AbstractTCKTest {
 
 		constraintViolations = validator.validate( dummy );
 
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "bytePrimitive" ),
-				pathWith()
-						.property( "intPrimitive" ),
-				pathWith()
-						.property( "longPrimitive" ),
-				pathWith()
-						.property( "shortPrimitive" ),
-				pathWith()
-						.property( "doublePrimitive" ),
-				pathWith()
-						.property( "floatPrimitive" ),
-				pathWith()
-						.property( "byteObject" ),
-				pathWith()
-						.property( "intObject" ),
-				pathWith()
-						.property( "longObject" ),
-				pathWith()
-						.property( "shortObject" ),
-				pathWith()
-						.property( "doubleObject" ),
-				pathWith()
-						.property( "floatObject" ),
-				pathWith()
-						.property( "bigDecimal" ),
-				pathWith()
-						.property( "bigInteger" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Negative.class ).withProperty( "bytePrimitive" ),
+				violationOf( Negative.class ).withProperty( "intPrimitive" ),
+				violationOf( Negative.class ).withProperty( "longPrimitive" ),
+				violationOf( Negative.class ).withProperty( "shortPrimitive" ),
+				violationOf( Negative.class ).withProperty( "doublePrimitive" ),
+				violationOf( Negative.class ).withProperty( "floatPrimitive" ),
+				violationOf( Negative.class ).withProperty( "byteObject" ),
+				violationOf( Negative.class ).withProperty( "intObject" ),
+				violationOf( Negative.class ).withProperty( "longObject" ),
+				violationOf( Negative.class ).withProperty( "shortObject" ),
+				violationOf( Negative.class ).withProperty( "doubleObject" ),
+				violationOf( Negative.class ).withProperty( "floatObject" ),
+				violationOf( Negative.class ).withProperty( "bigDecimal" ),
+				violationOf( Negative.class ).withProperty( "bigInteger" )
 		);
 
 		dummy.intPrimitive = -101;
@@ -179,7 +145,7 @@ public class NegativePositiveConstraintsTest extends AbstractTCKTest {
 		dummy.bigInteger = BigInteger.valueOf( -100 );
 
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	@Test
@@ -199,28 +165,24 @@ public class NegativePositiveConstraintsTest extends AbstractTCKTest {
 		dummy.doubleObject = Double.NEGATIVE_INFINITY;
 
 		Set<ConstraintViolation<NegativeEntity>> constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		dummy.floatObject = Float.POSITIVE_INFINITY;
 		dummy.doubleObject = Double.POSITIVE_INFINITY;
 
 		constraintViolations = validator.validate( dummy );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "doubleObject" ),
-				pathWith()
-						.property( "floatObject" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Negative.class ).withProperty( "doubleObject" ),
+				violationOf( Negative.class ).withProperty( "floatObject" )
 		);
 
 		dummy.floatObject = Float.NaN;
 		dummy.doubleObject = Double.NaN;
 
 		constraintViolations = validator.validate( dummy );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "doubleObject" ),
-				pathWith()
-						.property( "floatObject" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Negative.class ).withProperty( "doubleObject" ),
+				violationOf( Negative.class ).withProperty( "floatObject" )
 		);
 	}
 
@@ -232,7 +194,7 @@ public class NegativePositiveConstraintsTest extends AbstractTCKTest {
 		NegativeOrZeroEntity dummy = new NegativeOrZeroEntity();
 
 		Set<ConstraintViolation<NegativeOrZeroEntity>> constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		dummy.intPrimitive = 101;
 		dummy.longPrimitive = 1001;
@@ -250,35 +212,21 @@ public class NegativePositiveConstraintsTest extends AbstractTCKTest {
 		dummy.bigInteger = BigInteger.valueOf( 100 );
 
 		constraintViolations = validator.validate( dummy );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "bytePrimitive" ),
-				pathWith()
-						.property( "intPrimitive" ),
-				pathWith()
-						.property( "longPrimitive" ),
-				pathWith()
-						.property( "shortPrimitive" ),
-				pathWith()
-						.property( "doublePrimitive" ),
-				pathWith()
-						.property( "floatPrimitive" ),
-				pathWith()
-						.property( "byteObject" ),
-				pathWith()
-						.property( "intObject" ),
-				pathWith()
-						.property( "longObject" ),
-				pathWith()
-						.property( "shortObject" ),
-				pathWith()
-						.property( "doubleObject" ),
-				pathWith()
-						.property( "floatObject" ),
-				pathWith()
-						.property( "bigDecimal" ),
-				pathWith()
-						.property( "bigInteger" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NegativeOrZero.class ).withProperty( "bytePrimitive" ),
+				violationOf( NegativeOrZero.class ).withProperty( "intPrimitive" ),
+				violationOf( NegativeOrZero.class ).withProperty( "longPrimitive" ),
+				violationOf( NegativeOrZero.class ).withProperty( "shortPrimitive" ),
+				violationOf( NegativeOrZero.class ).withProperty( "doublePrimitive" ),
+				violationOf( NegativeOrZero.class ).withProperty( "floatPrimitive" ),
+				violationOf( NegativeOrZero.class ).withProperty( "byteObject" ),
+				violationOf( NegativeOrZero.class ).withProperty( "intObject" ),
+				violationOf( NegativeOrZero.class ).withProperty( "longObject" ),
+				violationOf( NegativeOrZero.class ).withProperty( "shortObject" ),
+				violationOf( NegativeOrZero.class ).withProperty( "doubleObject" ),
+				violationOf( NegativeOrZero.class ).withProperty( "floatObject" ),
+				violationOf( NegativeOrZero.class ).withProperty( "bigDecimal" ),
+				violationOf( NegativeOrZero.class ).withProperty( "bigInteger" )
 		);
 
 		dummy.intPrimitive = 0;
@@ -297,7 +245,7 @@ public class NegativePositiveConstraintsTest extends AbstractTCKTest {
 		dummy.bigInteger = BigInteger.valueOf( 0 );
 
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		dummy.intPrimitive = -101;
 		dummy.longPrimitive = -1001;
@@ -315,7 +263,7 @@ public class NegativePositiveConstraintsTest extends AbstractTCKTest {
 		dummy.bigInteger = BigInteger.valueOf( -100 );
 
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	@Test
@@ -329,28 +277,24 @@ public class NegativePositiveConstraintsTest extends AbstractTCKTest {
 		dummy.doubleObject = Double.NEGATIVE_INFINITY;
 
 		Set<ConstraintViolation<NegativeOrZeroEntity>> constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		dummy.floatObject = Float.POSITIVE_INFINITY;
 		dummy.doubleObject = Double.POSITIVE_INFINITY;
 
 		constraintViolations = validator.validate( dummy );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "doubleObject" ),
-				pathWith()
-						.property( "floatObject" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NegativeOrZero.class ).withProperty( "doubleObject" ),
+				violationOf( NegativeOrZero.class ).withProperty( "floatObject" )
 		);
 
 		dummy.floatObject = Float.NaN;
 		dummy.doubleObject = Double.NaN;
 
 		constraintViolations = validator.validate( dummy );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "doubleObject" ),
-				pathWith()
-						.property( "floatObject" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NegativeOrZero.class ).withProperty( "doubleObject" ),
+				violationOf( NegativeOrZero.class ).withProperty( "floatObject" )
 		);
 	}
 
@@ -362,19 +306,13 @@ public class NegativePositiveConstraintsTest extends AbstractTCKTest {
 		PositiveEntity dummy = new PositiveEntity();
 
 		Set<ConstraintViolation<PositiveEntity>> constraintViolations = validator.validate( dummy );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "bytePrimitive" ),
-				pathWith()
-						.property( "intPrimitive" ),
-				pathWith()
-						.property( "longPrimitive" ),
-				pathWith()
-						.property( "shortPrimitive" ),
-				pathWith()
-						.property( "doublePrimitive" ),
-				pathWith()
-						.property( "floatPrimitive" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Positive.class ).withProperty( "bytePrimitive" ),
+				violationOf( Positive.class ).withProperty( "intPrimitive" ),
+				violationOf( Positive.class ).withProperty( "longPrimitive" ),
+				violationOf( Positive.class ).withProperty( "shortPrimitive" ),
+				violationOf( Positive.class ).withProperty( "doublePrimitive" ),
+				violationOf( Positive.class ).withProperty( "floatPrimitive" )
 		);
 
 		dummy.intPrimitive = 101;
@@ -393,7 +331,7 @@ public class NegativePositiveConstraintsTest extends AbstractTCKTest {
 		dummy.bigInteger = BigInteger.valueOf( 100 );
 
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		dummy.intPrimitive = 0;
 		dummy.longPrimitive = 0;
@@ -412,35 +350,21 @@ public class NegativePositiveConstraintsTest extends AbstractTCKTest {
 
 		constraintViolations = validator.validate( dummy );
 
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "bytePrimitive" ),
-				pathWith()
-						.property( "intPrimitive" ),
-				pathWith()
-						.property( "longPrimitive" ),
-				pathWith()
-						.property( "shortPrimitive" ),
-				pathWith()
-						.property( "doublePrimitive" ),
-				pathWith()
-						.property( "floatPrimitive" ),
-				pathWith()
-						.property( "byteObject" ),
-				pathWith()
-						.property( "intObject" ),
-				pathWith()
-						.property( "longObject" ),
-				pathWith()
-						.property( "shortObject" ),
-				pathWith()
-						.property( "doubleObject" ),
-				pathWith()
-						.property( "floatObject" ),
-				pathWith()
-						.property( "bigDecimal" ),
-				pathWith()
-						.property( "bigInteger" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Positive.class ).withProperty( "bytePrimitive" ),
+				violationOf( Positive.class ).withProperty( "intPrimitive" ),
+				violationOf( Positive.class ).withProperty( "longPrimitive" ),
+				violationOf( Positive.class ).withProperty( "shortPrimitive" ),
+				violationOf( Positive.class ).withProperty( "doublePrimitive" ),
+				violationOf( Positive.class ).withProperty( "floatPrimitive" ),
+				violationOf( Positive.class ).withProperty( "byteObject" ),
+				violationOf( Positive.class ).withProperty( "intObject" ),
+				violationOf( Positive.class ).withProperty( "longObject" ),
+				violationOf( Positive.class ).withProperty( "shortObject" ),
+				violationOf( Positive.class ).withProperty( "doubleObject" ),
+				violationOf( Positive.class ).withProperty( "floatObject" ),
+				violationOf( Positive.class ).withProperty( "bigDecimal" ),
+				violationOf( Positive.class ).withProperty( "bigInteger" )
 		);
 
 		dummy.intPrimitive = -101;
@@ -459,35 +383,21 @@ public class NegativePositiveConstraintsTest extends AbstractTCKTest {
 		dummy.bigInteger = BigInteger.valueOf( -100 );
 
 		constraintViolations = validator.validate( dummy );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "bytePrimitive" ),
-				pathWith()
-						.property( "intPrimitive" ),
-				pathWith()
-						.property( "longPrimitive" ),
-				pathWith()
-						.property( "shortPrimitive" ),
-				pathWith()
-						.property( "doublePrimitive" ),
-				pathWith()
-						.property( "floatPrimitive" ),
-				pathWith()
-						.property( "byteObject" ),
-				pathWith()
-						.property( "intObject" ),
-				pathWith()
-						.property( "longObject" ),
-				pathWith()
-						.property( "shortObject" ),
-				pathWith()
-						.property( "doubleObject" ),
-				pathWith()
-						.property( "floatObject" ),
-				pathWith()
-						.property( "bigDecimal" ),
-				pathWith()
-						.property( "bigInteger" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Positive.class ).withProperty( "bytePrimitive" ),
+				violationOf( Positive.class ).withProperty( "intPrimitive" ),
+				violationOf( Positive.class ).withProperty( "longPrimitive" ),
+				violationOf( Positive.class ).withProperty( "shortPrimitive" ),
+				violationOf( Positive.class ).withProperty( "doublePrimitive" ),
+				violationOf( Positive.class ).withProperty( "floatPrimitive" ),
+				violationOf( Positive.class ).withProperty( "byteObject" ),
+				violationOf( Positive.class ).withProperty( "intObject" ),
+				violationOf( Positive.class ).withProperty( "longObject" ),
+				violationOf( Positive.class ).withProperty( "shortObject" ),
+				violationOf( Positive.class ).withProperty( "doubleObject" ),
+				violationOf( Positive.class ).withProperty( "floatObject" ),
+				violationOf( Positive.class ).withProperty( "bigDecimal" ),
+				violationOf( Positive.class ).withProperty( "bigInteger" )
 		);
 	}
 
@@ -508,28 +418,24 @@ public class NegativePositiveConstraintsTest extends AbstractTCKTest {
 		dummy.doubleObject = Double.POSITIVE_INFINITY;
 
 		Set<ConstraintViolation<PositiveEntity>> constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		dummy.floatObject = Float.NEGATIVE_INFINITY;
 		dummy.doubleObject = Double.NEGATIVE_INFINITY;
 
 		constraintViolations = validator.validate( dummy );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "doubleObject" ),
-				pathWith()
-						.property( "floatObject" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Positive.class ).withProperty( "doubleObject" ),
+				violationOf( Positive.class ).withProperty( "floatObject" )
 		);
 
 		dummy.floatObject = Float.NaN;
 		dummy.doubleObject = Double.NaN;
 
 		constraintViolations = validator.validate( dummy );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "doubleObject" ),
-				pathWith()
-						.property( "floatObject" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Positive.class ).withProperty( "doubleObject" ),
+				violationOf( Positive.class ).withProperty( "floatObject" )
 		);
 	}
 
@@ -541,7 +447,7 @@ public class NegativePositiveConstraintsTest extends AbstractTCKTest {
 		PositiveOrZeroEntity dummy = new PositiveOrZeroEntity();
 
 		Set<ConstraintViolation<PositiveOrZeroEntity>> constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		dummy.intPrimitive = 101;
 		dummy.longPrimitive = 1001;
@@ -559,7 +465,7 @@ public class NegativePositiveConstraintsTest extends AbstractTCKTest {
 		dummy.bigInteger = BigInteger.valueOf( 100 );
 
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		dummy.intPrimitive = 0;
 		dummy.longPrimitive = 0;
@@ -577,7 +483,7 @@ public class NegativePositiveConstraintsTest extends AbstractTCKTest {
 		dummy.bigInteger = BigInteger.valueOf( 0 );
 
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		dummy.intPrimitive = -101;
 		dummy.longPrimitive = -1001;
@@ -595,35 +501,21 @@ public class NegativePositiveConstraintsTest extends AbstractTCKTest {
 		dummy.bigInteger = BigInteger.valueOf( -100 );
 
 		constraintViolations = validator.validate( dummy );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "bytePrimitive" ),
-				pathWith()
-						.property( "intPrimitive" ),
-				pathWith()
-						.property( "longPrimitive" ),
-				pathWith()
-						.property( "shortPrimitive" ),
-				pathWith()
-						.property( "doublePrimitive" ),
-				pathWith()
-						.property( "floatPrimitive" ),
-				pathWith()
-						.property( "byteObject" ),
-				pathWith()
-						.property( "intObject" ),
-				pathWith()
-						.property( "longObject" ),
-				pathWith()
-						.property( "shortObject" ),
-				pathWith()
-						.property( "doubleObject" ),
-				pathWith()
-						.property( "floatObject" ),
-				pathWith()
-						.property( "bigDecimal" ),
-				pathWith()
-						.property( "bigInteger" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( PositiveOrZero.class ).withProperty( "bytePrimitive" ),
+				violationOf( PositiveOrZero.class ).withProperty( "intPrimitive" ),
+				violationOf( PositiveOrZero.class ).withProperty( "longPrimitive" ),
+				violationOf( PositiveOrZero.class ).withProperty( "shortPrimitive" ),
+				violationOf( PositiveOrZero.class ).withProperty( "doublePrimitive" ),
+				violationOf( PositiveOrZero.class ).withProperty( "floatPrimitive" ),
+				violationOf( PositiveOrZero.class ).withProperty( "byteObject" ),
+				violationOf( PositiveOrZero.class ).withProperty( "intObject" ),
+				violationOf( PositiveOrZero.class ).withProperty( "longObject" ),
+				violationOf( PositiveOrZero.class ).withProperty( "shortObject" ),
+				violationOf( PositiveOrZero.class ).withProperty( "doubleObject" ),
+				violationOf( PositiveOrZero.class ).withProperty( "floatObject" ),
+				violationOf( PositiveOrZero.class ).withProperty( "bigDecimal" ),
+				violationOf( PositiveOrZero.class ).withProperty( "bigInteger" )
 		);
 	}
 
@@ -638,28 +530,24 @@ public class NegativePositiveConstraintsTest extends AbstractTCKTest {
 		dummy.doubleObject = Double.POSITIVE_INFINITY;
 
 		Set<ConstraintViolation<PositiveOrZeroEntity>> constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		dummy.floatObject = Float.NEGATIVE_INFINITY;
 		dummy.doubleObject = Double.NEGATIVE_INFINITY;
 
 		constraintViolations = validator.validate( dummy );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "doubleObject" ),
-				pathWith()
-						.property( "floatObject" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( PositiveOrZero.class ).withProperty( "doubleObject" ),
+				violationOf( PositiveOrZero.class ).withProperty( "floatObject" )
 		);
 
 		dummy.floatObject = Float.NaN;
 		dummy.doubleObject = Double.NaN;
 
 		constraintViolations = validator.validate( dummy );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "doubleObject" ),
-				pathWith()
-						.property( "floatObject" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( PositiveOrZero.class ).withProperty( "doubleObject" ),
+				violationOf( PositiveOrZero.class ).withProperty( "floatObject" )
 		);
 	}
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/builtinconstraints/NotBlankConstraintTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/builtinconstraints/NotBlankConstraintTest.java
@@ -6,10 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.constraints.builtinconstraints;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintTypes;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.util.Set;
 
@@ -48,47 +47,37 @@ public class NotBlankConstraintTest extends AbstractTCKTest {
 		NotBlankDummyEntity foo = new NotBlankDummyEntity();
 
 		Set<ConstraintViolation<NotBlankDummyEntity>> constraintViolations = validator.validate( foo );
-		assertCorrectConstraintTypes( constraintViolations, NotBlank.class );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "name" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotBlank.class ).withProperty( "name" )
 		);
 
 		foo.name = "";
 		constraintViolations = validator.validate( foo );
-		assertCorrectConstraintTypes( constraintViolations, NotBlank.class );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "name" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotBlank.class ).withProperty( "name" )
 		);
 
 		foo.name = " ";
 		constraintViolations = validator.validate( foo );
-		assertCorrectConstraintTypes( constraintViolations, NotBlank.class );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "name" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotBlank.class ).withProperty( "name" )
 		);
 
 		foo.name = "\t";
 		constraintViolations = validator.validate( foo );
-		assertCorrectConstraintTypes( constraintViolations, NotBlank.class );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "name" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotBlank.class ).withProperty( "name" )
 		);
 
 		foo.name = "\n";
 		constraintViolations = validator.validate( foo );
-		assertCorrectConstraintTypes( constraintViolations, NotBlank.class );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "name" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotBlank.class ).withProperty( "name" )
 		);
 
 		foo.name = "john doe";
 		constraintViolations = validator.validate( foo );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	@Test
@@ -100,23 +89,19 @@ public class NotBlankConstraintTest extends AbstractTCKTest {
 		NotBlankStringBuilderDummyEntity foo = new NotBlankStringBuilderDummyEntity();
 
 		Set<ConstraintViolation<NotBlankStringBuilderDummyEntity>> constraintViolations = validator.validate( foo );
-		assertCorrectConstraintTypes( constraintViolations, NotBlank.class );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "name" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotBlank.class ).withProperty( "name" )
 		);
 
 		foo.name = new StringBuilder( " " );
 		constraintViolations = validator.validate( foo );
-		assertCorrectConstraintTypes( constraintViolations, NotBlank.class );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "name" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotBlank.class ).withProperty( "name" )
 		);
 
 		foo.name = new StringBuilder( "john doe" );
 		constraintViolations = validator.validate( foo );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	private class NotBlankDummyEntity {

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/builtinconstraints/NotEmptyConstraintTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/builtinconstraints/NotEmptyConstraintTest.java
@@ -6,10 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.constraints.builtinconstraints;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintTypes;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -67,36 +66,21 @@ public class NotEmptyConstraintTest extends AbstractTCKTest {
 		dummy.shortArray = new short[0];
 
 		Set<ConstraintViolation<NotEmptyDummyEntity>> constraintViolations = validator.validate( dummy );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "collection" ),
-				pathWith()
-						.property( "map" ),
-				pathWith()
-						.property( "string" ),
-				pathWith()
-						.property( "stringBuilder" ),
-				pathWith()
-						.property( "integerArray" ),
-				pathWith()
-						.property( "booleanArray" ),
-				pathWith()
-						.property( "byteArray" ),
-				pathWith()
-						.property( "charArray" ),
-				pathWith()
-						.property( "doubleArray" ),
-				pathWith()
-						.property( "floatArray" ),
-				pathWith()
-						.property( "intArray" ),
-				pathWith()
-						.property( "longArray" ),
-				pathWith()
-						.property( "shortArray" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotEmpty.class ).withProperty( "collection" ),
+				violationOf( NotEmpty.class ).withProperty( "map" ),
+				violationOf( NotEmpty.class ).withProperty( "string" ),
+				violationOf( NotEmpty.class ).withProperty( "stringBuilder" ),
+				violationOf( NotEmpty.class ).withProperty( "integerArray" ),
+				violationOf( NotEmpty.class ).withProperty( "booleanArray" ),
+				violationOf( NotEmpty.class ).withProperty( "byteArray" ),
+				violationOf( NotEmpty.class ).withProperty( "charArray" ),
+				violationOf( NotEmpty.class ).withProperty( "doubleArray" ),
+				violationOf( NotEmpty.class ).withProperty( "floatArray" ),
+				violationOf( NotEmpty.class ).withProperty( "intArray" ),
+				violationOf( NotEmpty.class ).withProperty( "longArray" ),
+				violationOf( NotEmpty.class ).withProperty( "shortArray" )
 		);
-		assertCorrectConstraintTypes( constraintViolations, NotEmpty.class, NotEmpty.class, NotEmpty.class, NotEmpty.class, NotEmpty.class, NotEmpty.class,
-				NotEmpty.class, NotEmpty.class, NotEmpty.class, NotEmpty.class, NotEmpty.class, NotEmpty.class, NotEmpty.class );
 
 		dummy.collection.add( "foo" );
 		dummy.string = "a";
@@ -112,7 +96,7 @@ public class NotEmptyConstraintTest extends AbstractTCKTest {
 		dummy.longArray = new long[1];
 		dummy.shortArray = new short[1];
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	private static class NotEmptyDummyEntity {

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/builtinconstraints/NullNotNullConstraintsTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/builtinconstraints/NullNotNullConstraintsTest.java
@@ -6,9 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.constraints.builtinconstraints;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertConstraintViolation;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.util.Set;
 
@@ -50,15 +50,16 @@ public class NullNotNullConstraintsTest extends AbstractTCKTest {
 		Object foo = new Object();
 		dummy.setProperty( foo );
 		Set<ConstraintViolation<NullDummyEntity>> constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 1 );
-
-		assertConstraintViolation(
-				constraintViolations.iterator().next(), NullDummyEntity.class, foo, pathWith().property( "property" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Null.class )
+						.withProperty( "property" )
+						.withInvalidValue( foo )
+						.withRootBeanClass( NullDummyEntity.class )
 		);
 
 		dummy.setProperty( null );
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	@Test
@@ -68,14 +69,16 @@ public class NullNotNullConstraintsTest extends AbstractTCKTest {
 		Validator validator = TestUtil.getValidatorUnderTest();
 		NotNullDummyEntity dummy = new NotNullDummyEntity();
 		Set<ConstraintViolation<NotNullDummyEntity>> constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertConstraintViolation(
-				constraintViolations.iterator().next(), NotNullDummyEntity.class, null, pathWith().property( "property" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withProperty( "property" )
+						.withInvalidValue( null )
+						.withRootBeanClass( NotNullDummyEntity.class )
 		);
 
 		dummy.setProperty( new Object() );
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	private static class NullDummyEntity {

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/builtinconstraints/PatternConstraintTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/builtinconstraints/PatternConstraintTest.java
@@ -6,9 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.constraints.builtinconstraints;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertConstraintViolation;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.util.Set;
 
@@ -48,18 +48,20 @@ public class PatternConstraintTest extends AbstractTCKTest {
 		PatternDummyEntity dummy = new PatternDummyEntity();
 
 		Set<ConstraintViolation<PatternDummyEntity>> constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		dummy.pattern = "ab cd";
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertConstraintViolation(
-				constraintViolations.iterator().next(), PatternDummyEntity.class, "ab cd", pathWith().property( "pattern" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Pattern.class )
+						.withProperty( "pattern" )
+						.withInvalidValue( "ab cd" )
+						.withRootBeanClass( PatternDummyEntity.class )
 		);
 
 		dummy.pattern = "wc 00";
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	private static class PatternDummyEntity {

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/builtinconstraints/SizeConstraintTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/builtinconstraints/SizeConstraintTest.java
@@ -6,10 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.constraints.builtinconstraints;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintTypes;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -53,7 +52,7 @@ public class SizeConstraintTest extends AbstractTCKTest {
 		SizeDummyEntity dummy = new SizeDummyEntity();
 
 		Set<ConstraintViolation<SizeDummyEntity>> constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		dummy.collection = new HashSet<String>();
 		dummy.collection.add( "foo" );
@@ -73,34 +72,20 @@ public class SizeConstraintTest extends AbstractTCKTest {
 		dummy.shortArray = new short[0];
 
 		constraintViolations = validator.validate( dummy );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "collection" ),
-				pathWith()
-						.property( "map" ),
-				pathWith()
-						.property( "string" ),
-				pathWith()
-						.property( "integerArray" ),
-				pathWith()
-						.property( "booleanArray" ),
-				pathWith()
-						.property( "byteArray" ),
-				pathWith()
-						.property( "charArray" ),
-				pathWith()
-						.property( "doubleArray" ),
-				pathWith()
-						.property( "floatArray" ),
-				pathWith()
-						.property( "intArray" ),
-				pathWith()
-						.property( "longArray" ),
-				pathWith()
-						.property( "shortArray" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Size.class ).withProperty( "collection" ),
+				violationOf( Size.class ).withProperty( "map" ),
+				violationOf( Size.class ).withProperty( "string" ),
+				violationOf( Size.class ).withProperty( "integerArray" ),
+				violationOf( Size.class ).withProperty( "booleanArray" ),
+				violationOf( Size.class ).withProperty( "byteArray" ),
+				violationOf( Size.class ).withProperty( "charArray" ),
+				violationOf( Size.class ).withProperty( "doubleArray" ),
+				violationOf( Size.class ).withProperty( "floatArray" ),
+				violationOf( Size.class ).withProperty( "intArray" ),
+				violationOf( Size.class ).withProperty( "longArray" ),
+				violationOf( Size.class ).withProperty( "shortArray" )
 		);
-		assertCorrectConstraintTypes( constraintViolations, Size.class, Size.class, Size.class, Size.class, Size.class, Size.class, Size.class, Size.class,
-				Size.class, Size.class, Size.class, Size.class );
 
 		dummy.collection.remove( "bar" );
 		dummy.string = "a";
@@ -115,7 +100,7 @@ public class SizeConstraintTest extends AbstractTCKTest {
 		dummy.shortArray = new short[1];
 		dummy.map.remove( "key1" );
 		constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	private static class SizeDummyEntity {

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/constraintcomposition/nestedconstraintcomposition/NestedConstraintCompositionTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/constraintcomposition/nestedconstraintcomposition/NestedConstraintCompositionTest.java
@@ -6,9 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.constraints.constraintcomposition.nestedconstraintcomposition;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintTypes;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.util.Set;
 
@@ -47,12 +47,9 @@ public class NestedConstraintCompositionTest extends AbstractTCKTest {
 		Validator validator = TestUtil.getValidatorUnderTest();
 		DummyEntity1 dummy = new DummyEntity1( "" );
 		Set<ConstraintViolation<DummyEntity1>> constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 2 );
-		assertCorrectConstraintTypes(
-				constraintViolations, Pattern.class, NestedConstraintSingleViolation.class
-		);
-		assertCorrectConstraintViolationMessages(
-				constraintViolations, "Pattern must match abc", "NestedConstraintSingleViolation failed."
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Pattern.class ).withMessage( "Pattern must match abc" ),
+				violationOf( NestedConstraintSingleViolation.class ).withMessage( "NestedConstraintSingleViolation failed." )
 		);
 	}
 
@@ -62,9 +59,9 @@ public class NestedConstraintCompositionTest extends AbstractTCKTest {
 		Validator validator = TestUtil.getValidatorUnderTest();
 		DummyEntity2 dummy = new DummyEntity2( "" );
 		Set<ConstraintViolation<DummyEntity2>> constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintTypes( constraintViolations, CompositeConstraint2.class );
-		assertCorrectConstraintViolationMessages( constraintViolations, "CompositeConstraint2 failed." );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( CompositeConstraint2.class ).withMessage( "CompositeConstraint2 failed." )
+		);
 	}
 
 	@Test
@@ -73,10 +70,10 @@ public class NestedConstraintCompositionTest extends AbstractTCKTest {
 		Validator validator = TestUtil.getValidatorUnderTest();
 		DummyEntity3 dummy = new DummyEntity3( "" );
 		Set<ConstraintViolation<DummyEntity3>> constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 3 );
-		assertCorrectConstraintTypes( constraintViolations, Pattern.class, Pattern.class, Size.class );
-		assertCorrectConstraintViolationMessages(
-				constraintViolations, "Pattern must match abc", "Pattern must match ...", "Size must be 3"
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Pattern.class ).withMessage( "Pattern must match abc" ),
+				violationOf( Pattern.class ).withMessage( "Pattern must match ..." ),
+				violationOf( Size.class ).withMessage( "Size must be 3" )
 		);
 	}
 
@@ -86,9 +83,9 @@ public class NestedConstraintCompositionTest extends AbstractTCKTest {
 		Validator validator = TestUtil.getValidatorUnderTest();
 		DummyEntity4 dummy = new DummyEntity4( "" );
 		Set<ConstraintViolation<DummyEntity4>> constraintViolations = validator.validate( dummy );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintTypes( constraintViolations, CompositeConstraint4.class );
-		assertCorrectConstraintViolationMessages( constraintViolations, "CompositeConstraint4 failed." );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( CompositeConstraint4.class ).withMessage( "CompositeConstraint4 failed." )
+		);
 	}
 
 	class DummyEntity1 {

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/constraintdefinition/ConstraintDefinitionsTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/constraintdefinition/ConstraintDefinitionsTest.java
@@ -6,7 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.constraints.constraintdefinition;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 import static org.testng.Assert.assertEquals;
 
 import java.util.Set;
@@ -59,7 +61,9 @@ public class ConstraintDefinitionsTest extends AbstractTCKTest {
 		}
 
 		Set<ConstraintViolation<Person>> constraintViolations = validator.validate( new Person( "John", "Doe" ) );
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( AlwaysValid.class )
+		);
 	}
 
 	@Test
@@ -81,13 +85,17 @@ public class ConstraintDefinitionsTest extends AbstractTCKTest {
 		}
 
 		Set<ConstraintViolation<Movie>> constraintViolations = validator.validate( new Movie( "Title" ) );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		constraintViolations = validator.validate( new Movie( "A" ) );
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Size.class )
+		);
 
 		constraintViolations = validator.validate( new Movie( "A movie title far too long that does not respect the constraint" ) );
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Size.class )
+		);
 	}
 
 	@Test

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/containerelement/NestedContainerElementConstraintsTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/containerelement/NestedContainerElementConstraintsTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.beanvalidation.tck.tests.constraints.containerelement;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
@@ -56,7 +56,7 @@ public class NestedContainerElementConstraintsTest extends AbstractTCKTest {
 	@SpecAssertion(section = Sections.VALIDATIONAPI_CONSTRAINTVIOLATION, id = "ah")
 	public void validation_of_nested_type_arguments_works_with_map_of_list_of_optional() {
 		Set<ConstraintViolation<MapOfLists>> constraintViolations = getValidator().validate( MapOfLists.valid() );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		constraintViolations = getValidator().validate( MapOfLists.invalidKey() );
 		assertThat( constraintViolations ).containsOnlyViolations(
@@ -129,7 +129,7 @@ public class NestedContainerElementConstraintsTest extends AbstractTCKTest {
 	@SpecAssertion(section = Sections.VALIDATIONAPI_CONSTRAINTVIOLATION, id = "ah")
 	public void validation_of_nested_type_arguments_works_with_map_of_list_of_stringproperty() {
 		Set<ConstraintViolation<MapOfListsWithAutomaticUnwrapping>> constraintViolations = getValidator().validate( MapOfListsWithAutomaticUnwrapping.valid() );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		constraintViolations = getValidator().validate( MapOfListsWithAutomaticUnwrapping.invalidStringProperty() );
 		assertThat( constraintViolations ).containsOnlyViolations(
@@ -181,7 +181,7 @@ public class NestedContainerElementConstraintsTest extends AbstractTCKTest {
 	@SpecAssertion(section = Sections.VALIDATIONAPI_CONSTRAINTVIOLATION, id = "ah")
 	public void validation_of_nested_type_arguments_works_with_list_of_maps() {
 		Set<ConstraintViolation<ListOfMaps>> constraintViolations = getValidator().validate( ListOfMaps.valid() );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		constraintViolations = getValidator().validate( ListOfMaps.invalidValue() );
 		assertThat( constraintViolations ).containsOnlyViolations(
@@ -201,7 +201,7 @@ public class NestedContainerElementConstraintsTest extends AbstractTCKTest {
 	@SpecAssertion(section = Sections.VALIDATIONAPI_CONSTRAINTVIOLATION, id = "ah")
 	public void validation_of_nested_type_arguments_works_with_list_of_iterables() {
 		Set<ConstraintViolation<ListOfIterables>> constraintViolations = getValidator().validate( ListOfIterables.valid() );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		constraintViolations = getValidator().validate( ListOfIterables.invalid() );
 		assertThat( constraintViolations ).containsOnlyViolations(

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/crossparameter/GenericAndCrossParameterConstraintTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/crossparameter/GenericAndCrossParameterConstraintTest.java
@@ -6,9 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.constraints.crossparameter;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintTypes;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
-import static org.testng.Assert.assertEquals;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.lang.reflect.Method;
 import java.util.Date;
@@ -52,12 +52,12 @@ public class GenericAndCrossParameterConstraintTest extends AbstractTCKTest {
 				method,
 				parameterValues
 		);
-		assertNumberOfViolations( violations, 0 );
+		assertNoViolations( violations );
 
 		violations = getExecutableValidator().validateReturnValue( object, method, returnValue );
-		assertNumberOfViolations( violations, 1 );
-		assertCorrectConstraintTypes( violations, GenericConstraint.class );
-		assertEquals( violations.iterator().next().getInvalidValue(), returnValue );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( GenericConstraint.class ).withInvalidValue( returnValue )
+		);
 	}
 
 	@Test
@@ -73,12 +73,12 @@ public class GenericAndCrossParameterConstraintTest extends AbstractTCKTest {
 				method,
 				parameterValues
 		);
-		assertNumberOfViolations( violations, 0 );
+		assertNoViolations( violations );
 
 		violations = getExecutableValidator().validateReturnValue( object, method, returnValue );
-		assertNumberOfViolations( violations, 1 );
-		assertCorrectConstraintTypes( violations, ExplicitGenericConstraint.class );
-		assertEquals( violations.iterator().next().getInvalidValue(), returnValue );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( ExplicitGenericConstraint.class ).withInvalidValue( returnValue )
+		);
 	}
 
 	@Test
@@ -94,12 +94,12 @@ public class GenericAndCrossParameterConstraintTest extends AbstractTCKTest {
 				method,
 				returnValue
 		);
-		assertNumberOfViolations( violations, 0 );
+		assertNoViolations( violations );
 
 		violations = getExecutableValidator().validateParameters( object, method, parameterValues );
-		assertNumberOfViolations( violations, 1 );
-		assertCorrectConstraintTypes( violations, CrossParameterConstraint.class );
-		assertEquals( violations.iterator().next().getInvalidValue(), parameterValues );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( CrossParameterConstraint.class ).withInvalidValue( parameterValues )
+		);
 	}
 
 	@Test
@@ -118,23 +118,23 @@ public class GenericAndCrossParameterConstraintTest extends AbstractTCKTest {
 				method,
 				parameterValues
 		);
-		assertNumberOfViolations( violations, 0 );
+		assertNoViolations( violations );
 
 		violations = getExecutableValidator().validateReturnValue( object, method, returnValue );
-		assertNumberOfViolations( violations, 1 );
-		assertCorrectConstraintTypes( violations, GenericAndCrossParameterConstraintWithOneValidator.class );
-		assertEquals( violations.iterator().next().getInvalidValue(), returnValue );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( GenericAndCrossParameterConstraintWithOneValidator.class ).withInvalidValue( returnValue )
+		);
 
 		method = MobileCalendar.class.getMethod( "addEvent", Date.class, Date.class );
 
 		//constraint applies to parameters
 		violations = getExecutableValidator().validateReturnValue( object, method, returnValue );
-		assertNumberOfViolations( violations, 0 );
+		assertNoViolations( violations );
 
 		violations = getExecutableValidator().validateParameters( object, method, parameterValues );
-		assertNumberOfViolations( violations, 1 );
-		assertCorrectConstraintTypes( violations, GenericAndCrossParameterConstraintWithOneValidator.class );
-		assertEquals( violations.iterator().next().getInvalidValue(), parameterValues );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( GenericAndCrossParameterConstraintWithOneValidator.class ).withInvalidValue( parameterValues )
+		);
 	}
 
 	private static class Calendar {

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/groups/groupsequence/SequenceResolutionTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/groups/groupsequence/SequenceResolutionTest.java
@@ -6,7 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.constraints.groups.groupsequence;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.util.Set;
 
@@ -71,18 +73,28 @@ public class SequenceResolutionTest extends AbstractTCKTest {
 
 		// the constraint fails for each group
 		Set<ConstraintViolation<Car>> violations = validator.validate( car, First.class );
-		assertNumberOfViolations( violations, 1 );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Pattern.class )
+		);
 
 		violations = validator.validate( car, Second.class );
-		assertNumberOfViolations( violations, 2 );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ),
+				violationOf( Pattern.class )
+		);
 
 		// if we validate against the sequence All we only get one violation since group Second won't be executed
 		violations = validator.validate( car, All.class );
-		assertNumberOfViolations( violations, 1 );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Pattern.class )
+		);
 
 		// if we validate against the sequence AllReverse we only get two violations since group First won't be executed
 		violations = validator.validate( car, AllReverse.class );
-		assertNumberOfViolations( violations, 2 );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ),
+				violationOf( Pattern.class )
+		);
 	}
 
 	class Car {

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/groups/inheritance/GroupInheritanceTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/groups/inheritance/GroupInheritanceTest.java
@@ -6,8 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.constraints.groups.inheritance;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintTypes;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 import static org.testng.Assert.assertEquals;
 
 import java.util.Set;
@@ -51,13 +52,15 @@ public class GroupInheritanceTest extends AbstractTCKTest {
 		part.setPartNumber( 123456 );
 
 		Set<ConstraintViolation<Part>> violations = validator.validate( part, All.class );
-		assertNumberOfViolations( violations, 2 );
-		assertCorrectConstraintTypes( violations, Digits.class, AssertTrue.class );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Digits.class ),
+				violationOf( AssertTrue.class )
+		);
 
 		part.setPartNumber( 12345 );
 		part.setQaChecked( true );
 		violations = validator.validate( part, All.class );
-		assertNumberOfViolations( violations, 0 );
+		assertNoViolations( violations );
 	}
 
 	@Test

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/inheritance/ConstraintInheritanceTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/inheritance/ConstraintInheritanceTest.java
@@ -6,7 +6,8 @@
  */
 package org.hibernate.beanvalidation.tck.tests.constraints.inheritance;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintTypes;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -113,11 +114,19 @@ public class ConstraintInheritanceTest extends AbstractTCKTest {
 	@SpecAssertion(section = Sections.CONSTRAINTDECLARATIONVALIDATIONPROCESS_VALIDATIONROUTINE, id = "a")
 	public void testValidationConsidersConstraintsFromSuperTypes() {
 		Set<ConstraintViolation<Bar>> violations = getValidator().validate( new Bar() );
-		assertCorrectConstraintTypes(
-				violations,
-				DecimalMin.class, DecimalMin.class, ValidBar.class, //Bar
-				NotNull.class, Size.class, ValidFoo.class, //Foo
-				NotNull.class, Size.class, ValidFubar.class //Fubar
+		assertThat( violations ).containsOnlyViolations(
+				//Bar
+				violationOf( DecimalMin.class ),
+				violationOf( DecimalMin.class ),
+				violationOf( ValidBar.class ),
+				//Foo
+				violationOf( NotNull.class ),
+				violationOf( Size.class ),
+				violationOf( ValidFoo.class ),
+				//Fubar
+				violationOf( NotNull.class ),
+				violationOf( Size.class ),
+				violationOf( ValidFubar.class )
 		);
 	}
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/inheritance/method/validdeclarations/ValidMethodConstraintDeclarationTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/constraints/inheritance/method/validdeclarations/ValidMethodConstraintDeclarationTest.java
@@ -6,9 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.constraints.inheritance.method.validdeclarations;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintTypes;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
@@ -67,7 +67,9 @@ public class ValidMethodConstraintDeclarationTest extends AbstractTCKTest {
 				returnValue
 		);
 
-		assertCorrectConstraintTypes( violations, NotNull.class );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+		);
 	}
 
 	@Test
@@ -83,7 +85,9 @@ public class ValidMethodConstraintDeclarationTest extends AbstractTCKTest {
 				returnValue
 		);
 
-		assertCorrectConstraintTypes( violations, NotNull.class );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+		);
 	}
 
 	@Test
@@ -99,12 +103,13 @@ public class ValidMethodConstraintDeclarationTest extends AbstractTCKTest {
 				returnValue
 		);
 
-		assertCorrectConstraintTypes( violations, NotNull.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( "createEvent" )
-						.returnValue()
-						.property( "name" )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.method( "createEvent" )
+								.returnValue()
+								.property( "name" )
+						)
 		);
 	}
 
@@ -121,7 +126,10 @@ public class ValidMethodConstraintDeclarationTest extends AbstractTCKTest {
 				returnValue
 		);
 
-		assertCorrectConstraintTypes( violations, NotNull.class, ValidCalendarEvent.class );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ),
+				violationOf( ValidCalendarEvent.class )
+		);
 	}
 
 	@Test
@@ -137,11 +145,10 @@ public class ValidMethodConstraintDeclarationTest extends AbstractTCKTest {
 				returnValue
 		);
 
-		assertCorrectConstraintTypes(
-				violations,
-				NotNull.class,
-				ValidCalendarEvent.class,
-				ValidBusinessCalendarEvent.class
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ),
+				violationOf( ValidBusinessCalendarEvent.class ),
+				violationOf( ValidCalendarEvent.class )
 		);
 	}
 
@@ -158,12 +165,13 @@ public class ValidMethodConstraintDeclarationTest extends AbstractTCKTest {
 				returnValue
 		);
 
-		assertCorrectConstraintTypes( violations, NotNull.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( "createEvent" )
-						.returnValue()
-						.property( "name" )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.method( "createEvent" )
+								.returnValue()
+								.property( "name" )
+						)
 		);
 	}
 
@@ -178,7 +186,9 @@ public class ValidMethodConstraintDeclarationTest extends AbstractTCKTest {
 				parameterValues
 		);
 
-		assertCorrectConstraintTypes( violations, Min.class );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Min.class )
+		);
 	}
 
 	@Test
@@ -192,12 +202,13 @@ public class ValidMethodConstraintDeclarationTest extends AbstractTCKTest {
 				parameterValues
 		);
 
-		assertCorrectConstraintTypes( violations, NotNull.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( CalendarServiceSubClass.class )
-						.parameter( "defaultEvent", 0 )
-						.property( "name" )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.constructor( CalendarServiceSubClass.class )
+								.parameter( "defaultEvent", 0 )
+								.property( "name" )
+						)
 		);
 	}
 
@@ -213,11 +224,12 @@ public class ValidMethodConstraintDeclarationTest extends AbstractTCKTest {
 		);
 
 		//only the constraint on the sub-type constructor should be validated
-		assertCorrectConstraintTypes( violations, ValidCalendarServiceSubClass.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( CalendarServiceSubClass.class )
-						.returnValue()
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( ValidCalendarServiceSubClass.class )
+						.withPropertyPath( pathWith()
+								.constructor( CalendarServiceSubClass.class )
+								.returnValue()
+						)
 		);
 	}
 
@@ -232,12 +244,13 @@ public class ValidMethodConstraintDeclarationTest extends AbstractTCKTest {
 				returnValue
 		);
 
-		assertCorrectConstraintTypes( violations, Min.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( CalendarServiceSubClass.class )
-						.returnValue()
-						.property( "mode" )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Min.class )
+						.withPropertyPath( pathWith()
+								.constructor( CalendarServiceSubClass.class )
+								.returnValue()
+								.property( "mode" )
+						)
 		);
 	}
 
@@ -254,12 +267,13 @@ public class ValidMethodConstraintDeclarationTest extends AbstractTCKTest {
 				returnValue
 		);
 
-		assertCorrectConstraintTypes( violations, NotNull.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( "createEvent" )
-						.returnValue()
-						.property( "name" )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.method( "createEvent" )
+								.returnValue()
+								.property( "name" )
+						)
 		);
 	}
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/defaultinjection/DefaultInjectionTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/defaultinjection/DefaultInjectionTest.java
@@ -6,7 +6,8 @@
  */
 package org.hibernate.beanvalidation.tck.tests.integration.cdi.defaultinjection;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
@@ -74,7 +75,9 @@ public class DefaultInjectionTest extends AbstractTCKTest {
 				.validate( new Foo() );
 
 		//expecting message from interpolator configured in META-INF/validation.xml
-		assertCorrectConstraintViolationMessages( violations, "Invalid constraint" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withMessage( "Invalid constraint" )
+		);
 	}
 
 	@Test
@@ -95,7 +98,9 @@ public class DefaultInjectionTest extends AbstractTCKTest {
 				.validate( new Foo() );
 
 		//expecting message from interpolator configured in META-INF/validation.xml
-		assertCorrectConstraintViolationMessages( violations, "Invalid constraint" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withMessage( "Invalid constraint" )
+		);
 	}
 
 	@Test
@@ -109,7 +114,9 @@ public class DefaultInjectionTest extends AbstractTCKTest {
 		Set<ConstraintViolation<Foo>> violations = defaultValidator.validate( new Foo() );
 
 		//expecting message from interpolator configured in META-INF/validation.xml
-		assertCorrectConstraintViolationMessages( violations, "Invalid constraint" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withMessage( "Invalid constraint" )
+		);
 	}
 
 	@Test
@@ -125,7 +132,9 @@ public class DefaultInjectionTest extends AbstractTCKTest {
 		Set<ConstraintViolation<Foo>> violations = qualifiedDefaultValidator.validate( new Foo() );
 
 		//expecting message from interpolator configured in META-INF/validation.xml
-		assertCorrectConstraintViolationMessages( violations, "Invalid constraint" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withMessage( "Invalid constraint" )
+		);
 	}
 
 	private static class Foo {

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/executable/ExecutableValidationTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/executable/ExecutableValidationTest.java
@@ -6,7 +6,8 @@
  */
 package org.hibernate.beanvalidation.tck.tests.integration.cdi.executable;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintTypes;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
@@ -101,11 +102,10 @@ public class ExecutableValidationTest extends AbstractTCKTest {
 			fail( "Method invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes(
-					e.getConstraintViolations(),
-					NotNull.class,
-					Future.class,
-					CrossParameterConstraint.class
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( NotNull.class ),
+					violationOf( Future.class ),
+					violationOf( CrossParameterConstraint.class )
 			);
 		}
 	}
@@ -121,7 +121,9 @@ public class ExecutableValidationTest extends AbstractTCKTest {
 			fail( "Method invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes( e.getConstraintViolations(), NotNull.class );
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( NotNull.class )
+			);
 		}
 	}
 
@@ -136,7 +138,9 @@ public class ExecutableValidationTest extends AbstractTCKTest {
 			fail( "Method invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes( e.getConstraintViolations(), NotNull.class );
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( NotNull.class )
+			);
 		}
 	}
 
@@ -162,7 +166,10 @@ public class ExecutableValidationTest extends AbstractTCKTest {
 			fail( "Constructor invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes( e.getConstraintViolations(), Size.class, CrossParameterConstraint.class );
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( Size.class ),
+					violationOf( CrossParameterConstraint.class )
+			);
 		}
 	}
 
@@ -177,7 +184,9 @@ public class ExecutableValidationTest extends AbstractTCKTest {
 			fail( "Constructor invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes( e.getConstraintViolations(), ValidPersonService.class );
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( ValidPersonService.class )
+			);
 		}
 	}
 
@@ -189,7 +198,9 @@ public class ExecutableValidationTest extends AbstractTCKTest {
 			fail( "Method invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes( e.getConstraintViolations(), NotNull.class );
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( NotNull.class )
+			);
 		}
 	}
 
@@ -211,7 +222,9 @@ public class ExecutableValidationTest extends AbstractTCKTest {
 			fail( "Method invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes( e.getConstraintViolations(), NotNull.class );
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( NotNull.class )
+			);
 		}
 	}
 
@@ -233,7 +246,9 @@ public class ExecutableValidationTest extends AbstractTCKTest {
 			fail( "Method invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes( e.getConstraintViolations(), NotNull.class );
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( NotNull.class )
+			);
 		}
 	}
 
@@ -257,7 +272,9 @@ public class ExecutableValidationTest extends AbstractTCKTest {
 			fail( "Method invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes( e.getConstraintViolations(), Size.class );
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( Size.class )
+			);
 		}
 
 		//method should not be invoked
@@ -269,7 +286,9 @@ public class ExecutableValidationTest extends AbstractTCKTest {
 			fail( "Method invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes( e.getConstraintViolations(), DecimalMin.class );
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( DecimalMin.class )
+			);
 		}
 
 		//method should have been invoked
@@ -293,7 +312,9 @@ public class ExecutableValidationTest extends AbstractTCKTest {
 			fail( "Constructor invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes( e.getConstraintViolations(), Size.class );
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( Size.class )
+			);
 		}
 
 		//constructor should not be invoked
@@ -306,7 +327,9 @@ public class ExecutableValidationTest extends AbstractTCKTest {
 			fail( "Constructor invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes( e.getConstraintViolations(), ValidAnotherBookingService.class );
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( ValidAnotherBookingService.class )
+			);
 		}
 
 		//constructor should have been invoked
@@ -328,7 +351,9 @@ public class ExecutableValidationTest extends AbstractTCKTest {
 			fail( "Method invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes( e.getConstraintViolations(), NotNull.class );
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( NotNull.class )
+			);
 		}
 	}
 
@@ -340,7 +365,9 @@ public class ExecutableValidationTest extends AbstractTCKTest {
 			fail( "Method invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes( e.getConstraintViolations(), NotNull.class );
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( NotNull.class )
+			);
 		}
 	}
 
@@ -352,7 +379,9 @@ public class ExecutableValidationTest extends AbstractTCKTest {
 			fail( "Method invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes( e.getConstraintViolations(), NotNull.class );
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( NotNull.class )
+			);
 		}
 	}
 
@@ -364,7 +393,9 @@ public class ExecutableValidationTest extends AbstractTCKTest {
 			fail( "Method invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes( e.getConstraintViolations(), NotNull.class );
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( NotNull.class )
+			);
 		}
 	}
 
@@ -376,7 +407,9 @@ public class ExecutableValidationTest extends AbstractTCKTest {
 			fail( "Method invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes( e.getConstraintViolations(), NotNull.class );
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( NotNull.class )
+			);
 		}
 	}
 
@@ -388,7 +421,9 @@ public class ExecutableValidationTest extends AbstractTCKTest {
 			fail( "Method invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes( e.getConstraintViolations(), NotNull.class );
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( NotNull.class )
+			);
 		}
 	}
 
@@ -400,7 +435,9 @@ public class ExecutableValidationTest extends AbstractTCKTest {
 			fail( "Method invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes( e.getConstraintViolations(), NotNull.class );
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( NotNull.class )
+			);
 		}
 	}
 
@@ -412,7 +449,9 @@ public class ExecutableValidationTest extends AbstractTCKTest {
 			fail( "Method invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes( e.getConstraintViolations(), NotNull.class );
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( NotNull.class )
+			);
 		}
 
 		String expressDelivery = deliveryService.createExpressDelivery( null );

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/executable/global/ExecutableValidationBasedOnGlobalConfigurationTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/executable/global/ExecutableValidationBasedOnGlobalConfigurationTest.java
@@ -6,7 +6,8 @@
  */
 package org.hibernate.beanvalidation.tck.tests.integration.cdi.executable.global;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintTypes;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.fail;
 
@@ -51,7 +52,9 @@ public class ExecutableValidationBasedOnGlobalConfigurationTest extends Abstract
 			fail( "Method invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes( e.getConstraintViolations(), NotNull.class );
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( NotNull.class )
+			);
 		}
 	}
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/executable/types/ExecutableTypesTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/executable/types/ExecutableTypesTest.java
@@ -6,7 +6,8 @@
  */
 package org.hibernate.beanvalidation.tck.tests.integration.cdi.executable.types;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintTypes;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.fail;
@@ -91,9 +92,8 @@ public class ExecutableTypesTest extends AbstractTCKTest {
 			fail( "Method invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes(
-					e.getConstraintViolations(),
-					Min.class
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( Min.class )
 			);
 		}
 	}
@@ -106,9 +106,8 @@ public class ExecutableTypesTest extends AbstractTCKTest {
 			fail( "Constructor invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes(
-					e.getConstraintViolations(),
-					Size.class
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( Size.class )
 			);
 		}
 	}
@@ -121,9 +120,8 @@ public class ExecutableTypesTest extends AbstractTCKTest {
 			fail( "Constructor invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes(
-					e.getConstraintViolations(),
-					ValidObject.class
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( ValidObject.class )
 			);
 		}
 	}
@@ -146,9 +144,8 @@ public class ExecutableTypesTest extends AbstractTCKTest {
 			fail( "Method invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes(
-					e.getConstraintViolations(),
-					Min.class
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( Min.class )
 			);
 		}
 	}
@@ -161,9 +158,8 @@ public class ExecutableTypesTest extends AbstractTCKTest {
 			fail( "Method invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes(
-					e.getConstraintViolations(),
-					ValidObject.class
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( ValidObject.class )
 			);
 		}
 	}
@@ -186,9 +182,8 @@ public class ExecutableTypesTest extends AbstractTCKTest {
 			fail( "Method invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes(
-					e.getConstraintViolations(),
-					ValidObject.class
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( ValidObject.class )
 			);
 		}
 	}
@@ -211,9 +206,8 @@ public class ExecutableTypesTest extends AbstractTCKTest {
 			fail( "Method invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes(
-					e.getConstraintViolations(),
-					Min.class
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( Min.class )
 			);
 		}
 	}
@@ -226,9 +220,8 @@ public class ExecutableTypesTest extends AbstractTCKTest {
 			fail( "Method invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes(
-					e.getConstraintViolations(),
-					ValidObject.class
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( ValidObject.class )
 			);
 		}
 	}
@@ -241,9 +234,8 @@ public class ExecutableTypesTest extends AbstractTCKTest {
 			fail( "Constructor invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes(
-					e.getConstraintViolations(),
-					Size.class
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( Size.class )
 			);
 		}
 	}
@@ -256,9 +248,8 @@ public class ExecutableTypesTest extends AbstractTCKTest {
 			fail( "Method invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes(
-					e.getConstraintViolations(),
-					Min.class
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( Min.class )
 			);
 		}
 	}
@@ -271,9 +262,8 @@ public class ExecutableTypesTest extends AbstractTCKTest {
 			fail( "Method invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes(
-					e.getConstraintViolations(),
-					NotNull.class
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( NotNull.class )
 			);
 		}
 	}
@@ -286,9 +276,8 @@ public class ExecutableTypesTest extends AbstractTCKTest {
 			fail( "Getter invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes(
-					e.getConstraintViolations(),
-					NotNull.class
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( NotNull.class )
 			);
 		}
 	}
@@ -312,9 +301,8 @@ public class ExecutableTypesTest extends AbstractTCKTest {
 			fail( "Constructor invocation should have caused a ConstraintViolationException" );
 		}
 		catch ( ConstraintViolationException e ) {
-			assertCorrectConstraintTypes(
-					e.getConstraintViolations(),
-					Size.class
+			assertThat( e.getConstraintViolations() ).containsOnlyViolations(
+					violationOf( Size.class )
 			);
 		}
 	}

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/factory/ConstraintValidatorInjectionTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/factory/ConstraintValidatorInjectionTest.java
@@ -6,7 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.integration.cdi.factory;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
+
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.util.Set;
 
@@ -48,7 +50,10 @@ public class ConstraintValidatorInjectionTest extends AbstractTCKTest {
 	public void testDependencyInjectionIntoConstraintValidator() {
 		Set<ConstraintViolation<Foo>> violations = defaultValidatorFactory.getValidator().validate( new Foo() );
 
-		assertCorrectConstraintViolationMessages( violations, "Hello, Mr. bar!", "Good morning, Mr. qux!" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( GreetingConstraint.class ).withMessage( "Hello, Mr. bar!" ),
+				violationOf( GreetingConstraint.class ).withMessage( "Good morning, Mr. qux!" )
+		);
 	}
 
 	private static class Foo {

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/ee/JndiRetrievalTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/ee/JndiRetrievalTest.java
@@ -6,7 +6,8 @@
  */
 package org.hibernate.beanvalidation.tck.tests.integration.ee;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
@@ -16,6 +17,7 @@ import javax.naming.InitialContext;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
+import javax.validation.constraints.NotNull;
 
 import org.hibernate.beanvalidation.tck.beanvalidation.Sections;
 import org.hibernate.beanvalidation.tck.tests.AbstractTCKTest;
@@ -61,7 +63,9 @@ public class JndiRetrievalTest extends AbstractTCKTest {
 				.validate( new Foo() );
 
 		//expecting message from interpolator configured in META-INF/validation.xml
-		assertCorrectConstraintViolationMessages( violations, "Invalid constraint" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withMessage( "Invalid constraint" )
+		);
 	}
 
 	@Test
@@ -73,6 +77,8 @@ public class JndiRetrievalTest extends AbstractTCKTest {
 		Set<ConstraintViolation<Foo>> violations = validator.validate( new Foo() );
 
 		//expecting message from interpolator configured in META-INF/validation.xml
-		assertCorrectConstraintViolationMessages( violations, "Invalid constraint" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withMessage( "Invalid constraint" )
+		);
 	}
 }

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/ee/ValidationTestEjb.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/ee/ValidationTestEjb.java
@@ -6,7 +6,8 @@
  */
 package org.hibernate.beanvalidation.tck.tests.integration.ee;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
@@ -17,6 +18,7 @@ import javax.ejb.Stateless;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
+import javax.validation.constraints.NotNull;
 
 /**
  * A test EJB which retrieves validator and validator factory via
@@ -44,7 +46,9 @@ public class ValidationTestEjb {
 				.validate( new Foo() );
 
 		//expecting message from interpolator configured in META-INF/validation.xml
-		assertCorrectConstraintViolationMessages( violations, "Invalid constraint" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withMessage( "Invalid constraint" )
+		);
 	}
 
 	public void assertDefaultValidatorGetsInjected() {
@@ -53,6 +57,8 @@ public class ValidationTestEjb {
 		Set<ConstraintViolation<Foo>> violations = defaultValidator.validate( new Foo() );
 
 		//expecting message from interpolator configured in META-INF/validation.xml
-		assertCorrectConstraintViolationMessages( violations, "Invalid constraint" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withMessage( "Invalid constraint" )
+		);
 	}
 }

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/ee/cdi/ConstraintValidatorInjectionTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/ee/cdi/ConstraintValidatorInjectionTest.java
@@ -6,7 +6,8 @@
  */
 package org.hibernate.beanvalidation.tck.tests.integration.ee.cdi;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 import static org.testng.Assert.assertNotNull;
 
 import java.util.Set;
@@ -51,7 +52,10 @@ public class ConstraintValidatorInjectionTest extends AbstractTCKTest {
 
 		Set<ConstraintViolation<Foo>> violations = validatorFactory.getValidator().validate( new Foo() );
 
-		assertCorrectConstraintViolationMessages( violations, "Hello, bar!", "Good morning, qux!" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( GreetingConstraint.class ).withMessage( "Hello, Mr. bar!" ),
+				violationOf( GreetingConstraint.class ).withMessage( "Good morning, Mr. qux!" )
+		);
 	}
 
 	private static class Foo {

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/messageinterpolation/ExpressionLanguageMessageInterpolationTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/messageinterpolation/ExpressionLanguageMessageInterpolationTest.java
@@ -8,7 +8,8 @@ package org.hibernate.beanvalidation.tck.tests.messageinterpolation;
 
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -72,7 +73,9 @@ public class ExpressionLanguageMessageInterpolationTest extends AbstractTCKTest 
 	@SpecAssertion(section = Sections.VALIDATIONAPI_MESSAGE_DEFAULTMESSAGEINTERPOLATION_EXPRESSIONLANGUAGE, id = "b")
 	public void testInterpolationWithElExpression() {
 		Set<ConstraintViolation<TestBean>> violations = getValidator().validateProperty( new TestBean(), "firstName" );
-		assertCorrectConstraintViolationMessages( violations, "2" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withMessage( "2" )
+		);
 	}
 
 	@Test
@@ -80,7 +83,9 @@ public class ExpressionLanguageMessageInterpolationTest extends AbstractTCKTest 
 	@SpecAssertion(section = Sections.VALIDATIONAPI_MESSAGE_DEFAULTMESSAGEINTERPOLATION_EXPRESSIONLANGUAGE, id = "b")
 	public void testInterpolationWithSeveralElExpressions() {
 		Set<ConstraintViolation<TestBean>> violations = getValidator().validateProperty( new TestBean(), "lastName" );
-		assertCorrectConstraintViolationMessages( violations, "2 some text 6" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withMessage( "2 some text 6" )
+		);
 	}
 
 	@Test
@@ -88,28 +93,36 @@ public class ExpressionLanguageMessageInterpolationTest extends AbstractTCKTest 
 	@SpecAssertion(section = Sections.VALIDATIONAPI_MESSAGE_DEFAULTMESSAGEINTERPOLATION_EXPRESSIONLANGUAGE, id = "f")
 	public void testInterpolationWithUnknownElExpression() {
 		Set<ConstraintViolation<TestBean>> violations = getValidator().validateProperty( new TestBean(), "houseNo" );
-		assertCorrectConstraintViolationMessages( violations, "${unknown}" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withMessage( "${unknown}" )
+		);
 	}
 
 	@Test
 	@SpecAssertion(section = Sections.VALIDATIONAPI_MESSAGE_DEFAULTMESSAGEINTERPOLATION_EXPRESSIONLANGUAGE, id = "f")
 	public void testInterpolationWithInvalidElExpression() {
 		Set<ConstraintViolation<TestBean>> violations = getValidator().validateProperty( new TestBean(), "addition" );
-		assertCorrectConstraintViolationMessages( violations, "${1*}" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withMessage( "${1*}" )
+		);
 	}
 
 	@Test
 	@SpecAssertion(section = Sections.VALIDATIONAPI_MESSAGE_DEFAULTMESSAGEINTERPOLATION_EXPRESSIONLANGUAGE, id = "f")
 	public void testInterpolationWithElExpressionThrowingAnException() {
 		Set<ConstraintViolation<TestBean>> violations = getValidator().validateProperty( new TestBean(), "continent" );
-		assertCorrectConstraintViolationMessages( violations, "${validatedValue}" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( ValidContinent.class ).withMessage( "${validatedValue}" )
+		);
 	}
 
 	@Test
 	@SpecAssertion(section = Sections.VALIDATIONAPI_MESSAGE_DEFAULTMESSAGEINTERPOLATION_EXPRESSIONLANGUAGE, id = "a")
 	public void testInterpolationWithIncompleteElExpression() {
 		Set<ConstraintViolation<TestBean>> violations = getValidator().validateProperty( new TestBean(), "zipCode" );
-		assertCorrectConstraintViolationMessages( violations, "${incomplete" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withMessage( "${incomplete" )
+		);
 	}
 
 	@Test
@@ -117,7 +130,9 @@ public class ExpressionLanguageMessageInterpolationTest extends AbstractTCKTest 
 	@SpecAssertion(section = Sections.VALIDATIONAPI_MESSAGE_DEFAULTMESSAGEINTERPOLATION_EXPRESSIONLANGUAGE, id = "b")
 	public void testOnlyDollarSignIsSupportedForEnclosingElExpressions() {
 		Set<ConstraintViolation<TestBean>> violations = getValidator().validateProperty( new TestBean(), "middleName" );
-		assertCorrectConstraintViolationMessages( violations, "#{1+1}" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withMessage( "#{1+1}" )
+		);
 	}
 
 	@Test
@@ -125,7 +140,9 @@ public class ExpressionLanguageMessageInterpolationTest extends AbstractTCKTest 
 	@SpecAssertion(section = Sections.VALIDATIONAPI_MESSAGE_DEFAULTMESSAGEINTERPOLATION_EXPRESSIONLANGUAGE, id = "c")
 	public void testInterpolationUsingAnnotationAttributesInElExpression() {
 		Set<ConstraintViolation<TestBean>> violations = getValidator().validateProperty( new TestBean(), "street" );
-		assertCorrectConstraintViolationMessages( violations, "must be longer than 30" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class ).withMessage( "must be longer than 30" )
+		);
 	}
 
 	@Test
@@ -133,7 +150,9 @@ public class ExpressionLanguageMessageInterpolationTest extends AbstractTCKTest 
 	@SpecAssertion(section = Sections.VALIDATIONAPI_MESSAGE_DEFAULTMESSAGEINTERPOLATION_EXPRESSIONLANGUAGE, id = "c")
 	public void testInterpolationUsingGroupsAndPayloadInElExpression() {
 		Set<ConstraintViolation<TestBean>> violations = getValidator().validateProperty( new TestBean(), "country" );
-		assertCorrectConstraintViolationMessages( violations, "groups: Default, payload: CustomPayload" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withMessage( "groups: Default, payload: CustomPayload" )
+		);
 	}
 
 	@Test
@@ -141,7 +160,9 @@ public class ExpressionLanguageMessageInterpolationTest extends AbstractTCKTest 
 	@SpecAssertion(section = Sections.VALIDATIONAPI_MESSAGE_DEFAULTMESSAGEINTERPOLATION_EXPRESSIONLANGUAGE, id = "d")
 	public void testInterpolationUsingValidatedValueInElExpression() {
 		Set<ConstraintViolation<TestBean>> violations = getValidator().validateProperty( new TestBean(), "city" );
-		assertCorrectConstraintViolationMessages( violations, "Foo is not long enough" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class ).withMessage( "Foo is not long enough" )
+		);
 	}
 
 	@Test
@@ -149,7 +170,9 @@ public class ExpressionLanguageMessageInterpolationTest extends AbstractTCKTest 
 	@SpecAssertion(section = Sections.VALIDATIONAPI_MESSAGE_DEFAULTMESSAGEINTERPOLATION_EXPRESSIONLANGUAGE, id = "e")
 	public void testInterpolationUsingFormatterInElExpression() {
 		Set<ConstraintViolation<TestBean>> violations = getValidator().validateProperty( new TestBean(), "longitude" );
-		assertCorrectConstraintViolationMessages( violations, "98.12 must be larger than 100" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Min.class ).withMessage( "98.12 must be larger than 100" )
+		);
 	}
 
 	@Test
@@ -157,7 +180,9 @@ public class ExpressionLanguageMessageInterpolationTest extends AbstractTCKTest 
 	@SpecAssertion(section = Sections.VALIDATIONAPI_MESSAGE_DEFAULTMESSAGEINTERPOLATION_EXPRESSIONLANGUAGE, id = "e")
 	public void testInterpolationUsingFormatterWithSeveralObjectsInElExpression() {
 		Set<ConstraintViolation<TestBean>> violations = getValidator().validateProperty( new TestBean(), "latitude" );
-		assertCorrectConstraintViolationMessages( violations, "98.12 (that is, 98.1235) must be larger than 100" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Min.class ).withMessage( "98.12 (that is, 98.1235) must be larger than 100" )
+		);
 	}
 
 	@Test
@@ -167,7 +192,9 @@ public class ExpressionLanguageMessageInterpolationTest extends AbstractTCKTest 
 		Locale.setDefault( Locale.GERMAN );
 		Validator validator = TestUtil.getValidatorUnderTest();
 		Set<ConstraintViolation<TestBean>> violations = validator.validateProperty( new TestBean(), "longitude" );
-		assertCorrectConstraintViolationMessages( violations, "98,12 must be larger than 100" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Min.class ).withMessage( "98,12 must be larger than 100" )
+		);
 	}
 
 	private interface CustomPayload extends Payload {

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ExecutableValidationIgnoresValidatedExecutableAnnotationSettingsTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ExecutableValidationIgnoresValidatedExecutableAnnotationSettingsTest.java
@@ -6,9 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.methodvalidation;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintTypes;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
@@ -61,9 +61,12 @@ public class ExecutableValidationIgnoresValidatedExecutableAnnotationSettingsTes
 				parameterValues
 		);
 
-		assertCorrectConstraintTypes( violations, NotNull.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith().method( methodName ).parameter( "name", 0 )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "name", 0 )
+						)
 		);
 	}
 
@@ -79,9 +82,12 @@ public class ExecutableValidationIgnoresValidatedExecutableAnnotationSettingsTes
 				parameterValues
 		);
 
-		assertCorrectConstraintTypes( violations, NotNull.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith().constructor( LineItem.class ).parameter( "name", 0 )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.constructor( LineItem.class )
+								.parameter( "name", 0 )
+						)
 		);
 	}
 
@@ -100,9 +106,12 @@ public class ExecutableValidationIgnoresValidatedExecutableAnnotationSettingsTes
 				returnValue
 		);
 
-		assertCorrectConstraintTypes( violations, NotNull.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith().method( methodName ).returnValue()
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.returnValue()
+						)
 		);
 	}
 
@@ -118,9 +127,12 @@ public class ExecutableValidationIgnoresValidatedExecutableAnnotationSettingsTes
 				createdObject
 		);
 
-		assertCorrectConstraintTypes( violations, ValidLineItem.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith().constructor( LineItem.class ).returnValue()
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( ValidLineItem.class )
+						.withPropertyPath( pathWith()
+								.constructor( LineItem.class )
+								.returnValue()
+						)
 		);
 	}
 
@@ -139,9 +151,12 @@ public class ExecutableValidationIgnoresValidatedExecutableAnnotationSettingsTes
 				parameterValues
 		);
 
-		assertCorrectConstraintTypes( violations, NotNull.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith().method( methodName ).parameter( "name", 0 )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "name", 0 )
+						)
 		);
 	}
 
@@ -157,9 +172,12 @@ public class ExecutableValidationIgnoresValidatedExecutableAnnotationSettingsTes
 				parameterValues
 		);
 
-		assertCorrectConstraintTypes( violations, NotNull.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith().constructor( WarehouseItem.class ).parameter( "name", 0 )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.constructor( WarehouseItem.class )
+								.parameter( "name", 0 )
+						)
 		);
 	}
 
@@ -178,9 +196,12 @@ public class ExecutableValidationIgnoresValidatedExecutableAnnotationSettingsTes
 				returnValue
 		);
 
-		assertCorrectConstraintTypes( violations, NotNull.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith().method( methodName ).returnValue()
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.returnValue()
+						)
 		);
 	}
 
@@ -196,9 +217,12 @@ public class ExecutableValidationIgnoresValidatedExecutableAnnotationSettingsTes
 				createdObject
 		);
 
-		assertCorrectConstraintTypes( violations, ValidWarehouseItem.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith().constructor( WarehouseItem.class ).returnValue()
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( ValidWarehouseItem.class )
+						.withPropertyPath( pathWith()
+								.constructor( WarehouseItem.class )
+								.returnValue()
+						)
 		);
 	}
 }

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ExecutableValidationIgnoresValidatedExecutableXmlSettingsTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ExecutableValidationIgnoresValidatedExecutableXmlSettingsTest.java
@@ -6,9 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.methodvalidation;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintTypes;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 import static org.testng.Assert.assertEquals;
 
 import java.lang.reflect.Constructor;
@@ -65,11 +65,12 @@ public class ExecutableValidationIgnoresValidatedExecutableXmlSettingsTest exten
 				parameterValues
 		);
 
-		assertCorrectConstraintTypes( violations, NotNull.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+				.withPropertyPath( pathWith()
 						.method( methodName )
 						.parameter( "name", 0 )
+				)
 		);
 	}
 
@@ -90,11 +91,12 @@ public class ExecutableValidationIgnoresValidatedExecutableXmlSettingsTest exten
 				parameterValues
 		);
 
-		assertCorrectConstraintTypes( violations, NotNull.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( StockItem.class )
-						.parameter( "name", 0 )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.constructor( StockItem.class )
+								.parameter( "name", 0 )
+						)
 		);
 	}
 
@@ -118,11 +120,12 @@ public class ExecutableValidationIgnoresValidatedExecutableXmlSettingsTest exten
 				returnValue
 		);
 
-		assertCorrectConstraintTypes( violations, NotNull.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.returnValue()
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.returnValue()
+						)
 		);
 	}
 
@@ -143,11 +146,12 @@ public class ExecutableValidationIgnoresValidatedExecutableXmlSettingsTest exten
 				createdObject
 		);
 
-		assertCorrectConstraintTypes( violations, ValidStockItem.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( StockItem.class )
-						.returnValue()
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( ValidStockItem.class )
+						.withPropertyPath( pathWith()
+								.constructor( StockItem.class )
+								.returnValue()
+						)
 		);
 	}
 }

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/MethodValidationTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/MethodValidationTest.java
@@ -6,10 +6,10 @@
  */
 package org.hibernate.beanvalidation.tck.tests.methodvalidation;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintTypes;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
@@ -81,27 +81,28 @@ public class MethodValidationTest extends AbstractTCKTest {
 				parameterValues
 		);
 
-		assertCorrectConstraintTypes(
-				violations,
-				NotNull.class,
-				Min.class,
-				Size.class,
-				MyCrossParameterConstraint.class
-		);
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.crossParameter(),
-				pathWith()
-						.method( methodName )
-						.parameter( "customer", 0 ),
-				pathWith()
-						.method( methodName )
-						.parameter( "item", 1 )
-						.property( "name" ),
-				pathWith()
-						.method( methodName )
-						.parameter( "quantity", 2 )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "customer", 0 )
+						),
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "item", 1 )
+								.property( "name" )
+						),
+				violationOf( Min.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "quantity", 2 )
+						),
+				violationOf( MyCrossParameterConstraint.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.crossParameter()
+						)
 		);
 	}
 
@@ -125,27 +126,28 @@ public class MethodValidationTest extends AbstractTCKTest {
 				parameterValues
 		);
 
-		assertCorrectConstraintTypes(
-				violations,
-				NotNull.class,
-				Min.class,
-				Size.class,
-				MyCrossParameterConstraint.class
-		);
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.crossParameter(),
-				pathWith()
-						.method( methodName )
-						.parameter( "customer", 0 ),
-				pathWith()
-						.method( methodName )
-						.parameter( "item", 1 )
-						.property( "name" ),
-				pathWith()
-						.method( methodName )
-						.parameter( "quantity", 2 )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "customer", 0 )
+						),
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "item", 1 )
+								.property( "name" )
+						),
+				violationOf( Min.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "quantity", 2 )
+						),
+				violationOf( MyCrossParameterConstraint.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.crossParameter()
+						)
 		);
 	}
 
@@ -170,27 +172,28 @@ public class MethodValidationTest extends AbstractTCKTest {
 				parameterValues
 		);
 
-		assertCorrectConstraintTypes(
-				violations,
-				NotNull.class,
-				Min.class,
-				Size.class,
-				MyCrossParameterConstraint.class
-		);
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.crossParameter(),
-				pathWith()
-						.method( methodName )
-						.parameter( "customer", 0 ),
-				pathWith()
-						.method( methodName )
-						.parameter( "item", 1 )
-						.property( "name" ),
-				pathWith()
-						.method( methodName )
-						.parameter( "quantity", 2 )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "customer", 0 )
+						),
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "item", 1 )
+								.property( "name" )
+						),
+				violationOf( Min.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "quantity", 2 )
+						),
+				violationOf( MyCrossParameterConstraint.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.crossParameter()
+						)
 		);
 	}
 
@@ -216,18 +219,17 @@ public class MethodValidationTest extends AbstractTCKTest {
 		);
 
 		//only constraints in Basic group should fail
-		assertCorrectConstraintTypes(
-				violations,
-				NotNull.class,
-				MyCrossParameterConstraint.class
-		);
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.crossParameter(),
-				pathWith()
-						.method( methodName )
-						.parameter( "customer", 0 )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "customer", 0 )
+						),
+				violationOf( MyCrossParameterConstraint.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.crossParameter()
+						)
 		);
 
 		violations = getExecutableValidator().validateParameters(
@@ -237,19 +239,18 @@ public class MethodValidationTest extends AbstractTCKTest {
 		);
 
 		//only constraints in Default group should fail
-		assertCorrectConstraintTypes(
-				violations,
-				Min.class,
-				Size.class
-		);
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.parameter( "item", 1 )
-						.property( "name" ),
-				pathWith()
-						.method( methodName )
-						.parameter( "quantity", 2 )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "item", 1 )
+								.property( "name" )
+						),
+				violationOf( Min.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "quantity", 2 )
+						)
 		);
 	}
 
@@ -274,12 +275,13 @@ public class MethodValidationTest extends AbstractTCKTest {
 				Basic.class
 		);
 
-		assertCorrectConstraintTypes( violations, Size.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.parameter( "item", 1 )
-						.property( "name" )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "item", 1 )
+								.property( "name" )
+						)
 		);
 	}
 
@@ -304,27 +306,28 @@ public class MethodValidationTest extends AbstractTCKTest {
 				Basic.class, Default.class
 		);
 
-		assertCorrectConstraintTypes(
-				violations,
-				NotNull.class,
-				Min.class,
-				Size.class,
-				MyCrossParameterConstraint.class
-		);
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.crossParameter(),
-				pathWith()
-						.method( methodName )
-						.parameter( "customer", 0 ),
-				pathWith()
-						.method( methodName )
-						.parameter( "item", 1 )
-						.property( "name" ),
-				pathWith()
-						.method( methodName )
-						.parameter( "quantity", 2 )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "customer", 0 )
+						),
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "item", 1 )
+								.property( "name" )
+						),
+				violationOf( Min.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "quantity", 2 )
+						),
+				violationOf( MyCrossParameterConstraint.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.crossParameter()
+						)
 		);
 	}
 
@@ -350,15 +353,18 @@ public class MethodValidationTest extends AbstractTCKTest {
 		);
 
 		//Only the constraints of the Basic group should fail
-		assertCorrectConstraintTypes( violations, Size.class, NotNull.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.parameter( "customer", 0 ),
-				pathWith()
-						.method( methodName )
-						.parameter( "item", 1 )
-						.property( "name" )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "customer", 0 )
+						),
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "item", 1 )
+								.property( "name" )
+						)
 		);
 
 		parameterValues = new Object[] { "Bob", new Item( "BV Specification" ), (byte) 0 };
@@ -371,14 +377,17 @@ public class MethodValidationTest extends AbstractTCKTest {
 		);
 
 		//Now the constraints of the Complex group should fail
-		assertCorrectConstraintTypes( violations, MyCrossParameterConstraint.class, Min.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.crossParameter(),
-				pathWith()
-						.method( methodName )
-						.parameter( "quantity", 2 )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Min.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "quantity", 2 )
+						),
+				violationOf( MyCrossParameterConstraint.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.crossParameter()
+						)
 		);
 	}
 
@@ -404,15 +413,18 @@ public class MethodValidationTest extends AbstractTCKTest {
 
 		//Only the constraints of the Basic group on OrderServiceWithRedefinedDefaultGroupSequence and of
 		//the Default group on Item should fail
-		assertCorrectConstraintTypes( violations, Size.class, NotNull.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.parameter( "customer", 0 ),
-				pathWith()
-						.method( methodName )
-						.parameter( "item", 1 )
-						.property( "name" )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "customer", 0 )
+						),
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "item", 1 )
+								.property( "name" )
+						)
 		);
 
 		parameterValues = new Object[] { "Bob", new Item( "" ), (byte) 0 };
@@ -425,23 +437,23 @@ public class MethodValidationTest extends AbstractTCKTest {
 
 		//Now the constraints of the Default group on OrderServiceWithRedefinedDefaultGroupSequence and of
 		//the Default group on Item should fail
-		assertCorrectConstraintTypes(
-				violations,
-				MyCrossParameterConstraint.class,
-				Size.class,
-				Min.class
-		);
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.crossParameter(),
-				pathWith()
-						.method( methodName )
-						.parameter( "item", 1 )
-						.property( "name" ),
-				pathWith()
-						.method( methodName )
-						.parameter( "quantity", 2 )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "item", 1 )
+								.property( "name" )
+						),
+				violationOf( Min.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "quantity", 2 )
+						),
+				violationOf( MyCrossParameterConstraint.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.crossParameter()
+						)
 		);
 	}
 
@@ -461,27 +473,28 @@ public class MethodValidationTest extends AbstractTCKTest {
 				parameterValues
 		);
 
-		assertCorrectConstraintTypes(
-				violations,
-				NotNull.class,
-				Min.class,
-				Size.class,
-				MyCrossParameterConstraint.class
-		);
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( OrderService.class )
-						.crossParameter(),
-				pathWith()
-						.constructor( OrderService.class )
-						.parameter( "customer", 0 ),
-				pathWith()
-						.constructor( OrderService.class )
-						.parameter( "item", 1 )
-						.property( "name" ),
-				pathWith()
-						.constructor( OrderService.class )
-						.parameter( "quantity", 2 )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderService.class )
+								.parameter( "customer", 0 )
+						),
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderService.class )
+								.parameter( "item", 1 )
+								.property( "name" )
+						),
+				violationOf( Min.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderService.class )
+								.parameter( "quantity", 2 )
+						),
+				violationOf( MyCrossParameterConstraint.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderService.class )
+								.crossParameter()
+						)
 		);
 	}
 
@@ -501,7 +514,7 @@ public class MethodValidationTest extends AbstractTCKTest {
 				parameterValues
 		);
 
-		assertNumberOfViolations( violations, 0 );
+		assertNoViolations( violations );
 	}
 
 	@Test
@@ -521,18 +534,17 @@ public class MethodValidationTest extends AbstractTCKTest {
 		);
 
 		//only constraints in Basic group should fail
-		assertCorrectConstraintTypes(
-				violations,
-				NotNull.class,
-				MyCrossParameterConstraint.class
-		);
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( OrderService.class )
-						.crossParameter(),
-				pathWith()
-						.constructor( OrderService.class )
-						.parameter( "customer", 0 )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderService.class )
+								.parameter( "customer", 0 )
+						),
+				violationOf( MyCrossParameterConstraint.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderService.class )
+								.crossParameter()
+						)
 		);
 
 		violations = getExecutableValidator().validateConstructorParameters(
@@ -541,19 +553,18 @@ public class MethodValidationTest extends AbstractTCKTest {
 		);
 
 		//only constraints in Default group should fail
-		assertCorrectConstraintTypes(
-				violations,
-				Min.class,
-				Size.class
-		);
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( OrderService.class )
-						.parameter( "item", 1 )
-						.property( "name" ),
-				pathWith()
-						.constructor( OrderService.class )
-						.parameter( "quantity", 2 )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderService.class )
+								.parameter( "item", 1 )
+								.property( "name" )
+						),
+				violationOf( Min.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderService.class )
+								.parameter( "quantity", 2 )
+						)
 		);
 	}
 
@@ -573,12 +584,13 @@ public class MethodValidationTest extends AbstractTCKTest {
 				Basic.class
 		);
 
-		assertCorrectConstraintTypes( violations, Size.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( OrderService.class )
-						.parameter( "item", 1 )
-						.property( "name" )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderService.class )
+								.parameter( "item", 1 )
+								.property( "name" )
+						)
 		);
 	}
 
@@ -598,27 +610,28 @@ public class MethodValidationTest extends AbstractTCKTest {
 				Basic.class, Default.class
 		);
 
-		assertCorrectConstraintTypes(
-				violations,
-				NotNull.class,
-				Min.class,
-				Size.class,
-				MyCrossParameterConstraint.class
-		);
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( OrderService.class )
-						.crossParameter(),
-				pathWith()
-						.constructor( OrderService.class )
-						.parameter( "customer", 0 ),
-				pathWith()
-						.constructor( OrderService.class )
-						.parameter( "item", 1 )
-						.property( "name" ),
-				pathWith()
-						.constructor( OrderService.class )
-						.parameter( "quantity", 2 )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderService.class )
+								.parameter( "customer", 0 )
+						),
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderService.class )
+								.parameter( "item", 1 )
+								.property( "name" )
+						),
+				violationOf( Min.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderService.class )
+								.parameter( "quantity", 2 )
+						),
+				violationOf( MyCrossParameterConstraint.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderService.class )
+								.crossParameter()
+						)
 		);
 	}
 
@@ -639,15 +652,18 @@ public class MethodValidationTest extends AbstractTCKTest {
 		);
 
 		//Only the constraints of the Basic group should fail
-		assertCorrectConstraintTypes( violations, Size.class, NotNull.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( OrderService.class )
-						.parameter( "customer", 0 ),
-				pathWith()
-						.constructor( OrderService.class )
-						.parameter( "item", 1 )
-						.property( "name" )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderService.class )
+								.parameter( "customer", 0 )
+						),
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderService.class )
+								.parameter( "item", 1 )
+								.property( "name" )
+						)
 		);
 
 		parameterValues = new Object[] { "Bob", new Item( "BV Specification" ), (byte) 0 };
@@ -659,14 +675,17 @@ public class MethodValidationTest extends AbstractTCKTest {
 		);
 
 		//Now the constraints of the Complex group should fail
-		assertCorrectConstraintTypes( violations, MyCrossParameterConstraint.class, Min.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( OrderService.class )
-						.crossParameter(),
-				pathWith()
-						.constructor( OrderService.class )
-						.parameter( "quantity", 2 )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Min.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderService.class )
+								.parameter( "quantity", 2 )
+						),
+				violationOf( MyCrossParameterConstraint.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderService.class )
+								.crossParameter()
+						)
 		);
 	}
 
@@ -689,15 +708,18 @@ public class MethodValidationTest extends AbstractTCKTest {
 
 		//Only the constraints of the Basic group on OrderServiceWithRedefinedDefaultGroupSequence and of
 		//the Default group on Item should fail
-		assertCorrectConstraintTypes( violations, Size.class, NotNull.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( OrderServiceWithRedefinedDefaultGroupSequence.class )
-						.parameter( "customer", 0 ),
-				pathWith()
-						.constructor( OrderServiceWithRedefinedDefaultGroupSequence.class )
-						.parameter( "item", 1 )
-						.property( "name" )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderServiceWithRedefinedDefaultGroupSequence.class )
+								.parameter( "customer", 0 )
+						),
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderServiceWithRedefinedDefaultGroupSequence.class )
+								.parameter( "item", 1 )
+								.property( "name" )
+						)
 		);
 
 		parameterValues = new Object[] { "Bob", new Item( "" ), (byte) 0 };
@@ -709,23 +731,23 @@ public class MethodValidationTest extends AbstractTCKTest {
 
 		//Now the constraints of the Default group on OrderServiceWithRedefinedDefaultGroupSequence and of
 		//the Default group on Item should fail
-		assertCorrectConstraintTypes(
-				violations,
-				MyCrossParameterConstraint.class,
-				Size.class,
-				Min.class
-		);
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( OrderServiceWithRedefinedDefaultGroupSequence.class )
-						.crossParameter(),
-				pathWith()
-						.constructor( OrderServiceWithRedefinedDefaultGroupSequence.class )
-						.parameter( "item", 1 )
-						.property( "name" ),
-				pathWith()
-						.constructor( OrderServiceWithRedefinedDefaultGroupSequence.class )
-						.parameter( "quantity", 2 )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderServiceWithRedefinedDefaultGroupSequence.class )
+								.parameter( "item", 1 )
+								.property( "name" )
+						),
+				violationOf( Min.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderServiceWithRedefinedDefaultGroupSequence.class )
+								.parameter( "quantity", 2 )
+						),
+				violationOf( MyCrossParameterConstraint.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderServiceWithRedefinedDefaultGroupSequence.class )
+								.crossParameter()
+						)
 		);
 	}
 
@@ -750,19 +772,18 @@ public class MethodValidationTest extends AbstractTCKTest {
 				returnValue
 		);
 
-		assertCorrectConstraintTypes(
-				violations,
-				ValidOrder.class,
-				Size.class
-		);
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.returnValue(),
-				pathWith()
-						.method( methodName )
-						.returnValue()
-						.property( "name" )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.returnValue()
+								.property( "name" )
+						),
+				violationOf( ValidOrder.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.returnValue()
+						)
 		);
 	}
 
@@ -786,23 +807,23 @@ public class MethodValidationTest extends AbstractTCKTest {
 				returnValue
 		);
 
-		assertCorrectConstraintTypes(
-				violations,
-				ValidOrder.class,
-				ValidRetailOrder.class,
-				Size.class
-		);
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.returnValue(),
-				pathWith()
-						.method( methodName )
-						.returnValue(),
-				pathWith()
-						.method( methodName )
-						.returnValue()
-						.property( "name" )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.returnValue()
+								.property( "name" )
+						),
+				violationOf( ValidOrder.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.returnValue()
+						),
+				violationOf( ValidRetailOrder.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.returnValue()
+						)
 		);
 	}
 
@@ -827,23 +848,23 @@ public class MethodValidationTest extends AbstractTCKTest {
 				returnValue
 		);
 
-		assertCorrectConstraintTypes(
-				violations,
-				ValidOrder.class,
-				ValidRetailOrder.class,
-				Size.class
-		);
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.returnValue(),
-				pathWith()
-						.method( methodName )
-						.returnValue(),
-				pathWith()
-						.method( methodName )
-						.returnValue()
-						.property( "name" )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.returnValue()
+								.property( "name" )
+						),
+				violationOf( ValidOrder.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.returnValue()
+						),
+				violationOf( ValidRetailOrder.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.returnValue()
+						)
 		);
 	}
 
@@ -869,14 +890,12 @@ public class MethodValidationTest extends AbstractTCKTest {
 		);
 
 		//only constraints in Basic group should fail
-		assertCorrectConstraintTypes(
-				violations,
-				ValidRetailOrder.class
-		);
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.returnValue()
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( ValidRetailOrder.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.returnValue()
+						)
 		);
 
 		violations = getExecutableValidator().validateReturnValue(
@@ -886,19 +905,18 @@ public class MethodValidationTest extends AbstractTCKTest {
 		);
 
 		//only constraints in Default group should fail
-		assertCorrectConstraintTypes(
-				violations,
-				ValidOrder.class,
-				Size.class
-		);
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.returnValue(),
-				pathWith()
-						.method( methodName )
-						.returnValue()
-						.property( "name" )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.returnValue()
+								.property( "name" )
+						),
+				violationOf( ValidOrder.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.returnValue()
+						)
 		);
 	}
 
@@ -923,12 +941,13 @@ public class MethodValidationTest extends AbstractTCKTest {
 				Basic.class
 		);
 
-		assertCorrectConstraintTypes( violations, Size.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.returnValue()
-						.property( "name" )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.returnValue()
+								.property( "name" )
+						)
 		);
 	}
 
@@ -953,14 +972,12 @@ public class MethodValidationTest extends AbstractTCKTest {
 				Basic.class, Default.class
 		);
 
-		assertCorrectConstraintTypes(
-				violations,
-				ValidOrder.class
-		);
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.returnValue()
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( ValidOrder.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.returnValue()
+						)
 		);
 	}
 
@@ -986,15 +1003,18 @@ public class MethodValidationTest extends AbstractTCKTest {
 		);
 
 		//Only the constraints of the Basic group should fail
-		assertCorrectConstraintTypes( violations, ValidOrder.class, Size.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.returnValue(),
-				pathWith()
-						.method( methodName )
-						.returnValue()
-						.property( "name" )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.returnValue()
+								.property( "name" )
+						),
+				violationOf( ValidOrder.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.returnValue()
+						)
 		);
 
 		returnValue = new Order( "BV Specification" );
@@ -1007,11 +1027,12 @@ public class MethodValidationTest extends AbstractTCKTest {
 		);
 
 		//Now the constraints of the Complex group should fail
-		assertCorrectConstraintTypes( violations, ValidRetailOrder.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.returnValue()
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( ValidRetailOrder.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.returnValue()
+						)
 		);
 	}
 
@@ -1037,15 +1058,18 @@ public class MethodValidationTest extends AbstractTCKTest {
 
 		//Only the constraints of the Basic group on OrderServiceWithRedefinedDefaultGroupSequence and of
 		//the Default group on Order should fail
-		assertCorrectConstraintTypes( violations, Size.class, ValidOrder.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.returnValue(),
-				pathWith()
-						.method( methodName )
-						.returnValue()
-						.property( "name" )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.returnValue()
+								.property( "name" )
+						),
+				violationOf( ValidOrder.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.returnValue()
+						)
 		);
 
 		returnValue = new Order( "valid" );
@@ -1058,15 +1082,18 @@ public class MethodValidationTest extends AbstractTCKTest {
 
 		//Now the constraints of the Default group on OrderServiceWithRedefinedDefaultGroupSequence and of
 		//the Default group on Order should fail
-		assertCorrectConstraintTypes( violations, Size.class, ValidRetailOrder.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.returnValue(),
-				pathWith()
-						.method( methodName )
-						.returnValue()
-						.property( "name" )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.returnValue()
+								.property( "name" )
+						),
+				violationOf( ValidRetailOrder.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.returnValue()
+						)
 		);
 	}
 
@@ -1085,20 +1112,18 @@ public class MethodValidationTest extends AbstractTCKTest {
 				constructor,
 				returnValue
 		);
-
-		assertCorrectConstraintTypes(
-				violations,
-				ValidOrderService.class,
-				Size.class
-		);
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( OrderService.class )
-						.returnValue(),
-				pathWith()
-						.constructor( OrderService.class )
-						.returnValue()
-						.property( "name" )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderService.class )
+								.returnValue()
+								.property( "name" )
+						),
+				violationOf( ValidOrderService.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderService.class )
+								.returnValue()
+						)
 		);
 	}
 
@@ -1118,14 +1143,12 @@ public class MethodValidationTest extends AbstractTCKTest {
 				returnValue
 		);
 
-		assertCorrectConstraintTypes(
-				violations,
-				ValidRetailOrderService.class
-		);
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( ExtendedOrderService.class )
-						.returnValue()
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( ValidRetailOrderService.class )
+						.withPropertyPath( pathWith()
+								.constructor( ExtendedOrderService.class )
+								.returnValue()
+						)
 		);
 	}
 
@@ -1146,14 +1169,12 @@ public class MethodValidationTest extends AbstractTCKTest {
 		);
 
 		//only constraints in Basic group should fail
-		assertCorrectConstraintTypes(
-				violations,
-				ValidRetailOrderService.class
-		);
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( OrderService.class )
-						.returnValue()
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( ValidRetailOrderService.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderService.class )
+								.returnValue()
+						)
 		);
 
 		violations = getExecutableValidator().validateConstructorReturnValue(
@@ -1162,19 +1183,18 @@ public class MethodValidationTest extends AbstractTCKTest {
 		);
 
 		//only constraints in Default group should fail
-		assertCorrectConstraintTypes(
-				violations,
-				ValidOrderService.class,
-				Size.class
-		);
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( OrderService.class )
-						.returnValue(),
-				pathWith()
-						.constructor( OrderService.class )
-						.returnValue()
-						.property( "name" )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( ValidOrderService.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderService.class )
+								.returnValue()
+						),
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderService.class )
+								.returnValue()
+								.property( "name" )
+						)
 		);
 	}
 
@@ -1194,12 +1214,13 @@ public class MethodValidationTest extends AbstractTCKTest {
 				Basic.class
 		);
 
-		assertCorrectConstraintTypes( violations, Size.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( OrderService.class )
-						.returnValue()
-						.property( "name" )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderService.class )
+								.returnValue()
+								.property( "name" )
+						)
 		);
 	}
 
@@ -1219,14 +1240,12 @@ public class MethodValidationTest extends AbstractTCKTest {
 				Basic.class, Default.class
 		);
 
-		assertCorrectConstraintTypes(
-				violations,
-				ValidOrderService.class
-		);
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( OrderService.class )
-						.returnValue()
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( ValidOrderService.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderService.class )
+								.returnValue()
+						)
 		);
 	}
 
@@ -1247,15 +1266,18 @@ public class MethodValidationTest extends AbstractTCKTest {
 		);
 
 		//Only the constraints of the Basic group should fail
-		assertCorrectConstraintTypes( violations, ValidOrderService.class, Size.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( OrderService.class )
-						.returnValue(),
-				pathWith()
-						.constructor( OrderService.class )
-						.returnValue()
-						.property( "name" )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( ValidOrderService.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderService.class )
+								.returnValue()
+						),
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderService.class )
+								.returnValue()
+								.property( "name" )
+						)
 		);
 
 		returnValue = new OrderService( "valid order service" );
@@ -1267,11 +1289,12 @@ public class MethodValidationTest extends AbstractTCKTest {
 		);
 
 		//Now the constraints of the Complex group should fail
-		assertCorrectConstraintTypes( violations, ValidRetailOrderService.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( OrderService.class )
-						.returnValue()
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( ValidRetailOrderService.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderService.class )
+								.returnValue()
+						)
 		);
 	}
 
@@ -1296,15 +1319,18 @@ public class MethodValidationTest extends AbstractTCKTest {
 				);
 
 		//Only the constraints of the Basic group should fail
-		assertCorrectConstraintTypes( violations, Size.class, ValidOrderService.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( OrderServiceWithRedefinedDefaultGroupSequence.class )
-						.returnValue(),
-				pathWith()
-						.constructor( OrderServiceWithRedefinedDefaultGroupSequence.class )
-						.returnValue()
-						.property( "name" )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( ValidOrderService.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderServiceWithRedefinedDefaultGroupSequence.class )
+								.returnValue()
+						),
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderServiceWithRedefinedDefaultGroupSequence.class )
+								.returnValue()
+								.property( "name" )
+						)
 		);
 
 		returnValue = new OrderServiceWithRedefinedDefaultGroupSequence( "valid" );
@@ -1315,15 +1341,18 @@ public class MethodValidationTest extends AbstractTCKTest {
 		);
 
 		//Now the constraints of the Default group should fail
-		assertCorrectConstraintTypes( violations, Pattern.class, ValidRetailOrderService.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( OrderServiceWithRedefinedDefaultGroupSequence.class )
-						.returnValue(),
-				pathWith()
-						.constructor( OrderServiceWithRedefinedDefaultGroupSequence.class )
-						.returnValue()
-						.property( "name" )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( ValidRetailOrderService.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderServiceWithRedefinedDefaultGroupSequence.class )
+								.returnValue()
+						),
+				violationOf( Pattern.class )
+						.withPropertyPath( pathWith()
+								.constructor( OrderServiceWithRedefinedDefaultGroupSequence.class )
+								.returnValue()
+								.property( "name" )
+						)
 		);
 	}
 }

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ValidateConstructorParametersTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ValidateConstructorParametersTest.java
@@ -6,10 +6,10 @@
  */
 package org.hibernate.beanvalidation.tck.tests.methodvalidation;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintTypes;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
@@ -75,13 +75,12 @@ public class ValidateConstructorParametersTest extends AbstractTCKTest {
 				parameterValues
 		);
 
-		assertNumberOfViolations( violations, 1 );
-
-		assertCorrectConstraintTypes( violations, Size.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( User.class )
-						.parameter( "firstName", 0 )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.constructor( User.class )
+								.parameter( "firstName", 0 )
+						)
 		);
 
 		ConstraintViolation<User> violation = violations.iterator().next();
@@ -106,13 +105,12 @@ public class ValidateConstructorParametersTest extends AbstractTCKTest {
 				parameterValues
 		);
 
-		assertNumberOfViolations( violations, 1 );
-
-		assertCorrectConstraintTypes( violations, MyCrossParameterConstraint.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( User.class )
-						.crossParameter()
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( MyCrossParameterConstraint.class )
+						.withPropertyPath( pathWith()
+								.constructor( User.class )
+								.crossParameter()
+						)
 		);
 
 		ConstraintViolation<User> violation = violations.iterator().next();
@@ -135,16 +133,17 @@ public class ValidateConstructorParametersTest extends AbstractTCKTest {
 				parameterValues
 		);
 
-		assertNumberOfViolations( violations, 2 );
-
-		assertCorrectConstraintTypes( violations, NotNull.class, Size.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( User.class )
-						.parameter( "firstName", 0 ),
-				pathWith()
-						.constructor( User.class )
-						.parameter( "lastName", 1 )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.constructor( User.class )
+								.parameter( "firstName", 0 )
+						),
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.constructor( User.class )
+								.parameter( "lastName", 1 )
+						)
 		);
 	}
 
@@ -159,16 +158,17 @@ public class ValidateConstructorParametersTest extends AbstractTCKTest {
 				parameterValues
 		);
 
-		assertNumberOfViolations( violations, 2 );
-
-		assertCorrectConstraintTypes( violations, Pattern.class, Size.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( User.class )
-						.parameter( "firstName", 0 ),
-				pathWith()
-						.constructor( User.class )
-						.parameter( "firstName", 0 )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Pattern.class )
+						.withPropertyPath( pathWith()
+								.constructor( User.class )
+								.parameter( "firstName", 0 )
+						),
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.constructor( User.class )
+								.parameter( "firstName", 0 )
+						)
 		);
 	}
 
@@ -183,16 +183,17 @@ public class ValidateConstructorParametersTest extends AbstractTCKTest {
 				parameterValues
 		);
 
-		assertNumberOfViolations( violations, 2 );
-
-		assertCorrectConstraintTypes( violations, Size.class, Size.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( User.class )
-						.parameter( "lastName", 0 ),
-				pathWith()
-						.constructor( User.class )
-						.parameter( "lastName", 0 )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.constructor( User.class )
+								.parameter( "lastName", 0 )
+						),
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.constructor( User.class )
+								.parameter( "lastName", 0 )
+						)
 		);
 	}
 
@@ -211,20 +212,17 @@ public class ValidateConstructorParametersTest extends AbstractTCKTest {
 				parameterValues
 		);
 
-		assertNumberOfViolations( violations, 2 );
-
-		assertCorrectConstraintTypes(
-				violations,
-				MyCrossParameterConstraint.class,
-				MyCrossParameterConstraint.class
-		);
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( User.class )
-						.crossParameter(),
-				pathWith()
-						.constructor( User.class )
-						.crossParameter()
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( MyCrossParameterConstraint.class )
+						.withPropertyPath( pathWith()
+								.constructor( User.class )
+								.crossParameter()
+						),
+				violationOf( MyCrossParameterConstraint.class )
+						.withPropertyPath( pathWith()
+								.constructor( User.class )
+								.crossParameter()
+						)
 		);
 	}
 
@@ -242,7 +240,7 @@ public class ValidateConstructorParametersTest extends AbstractTCKTest {
 				parameterValues
 		);
 
-		assertNumberOfViolations( violations, 0 );
+		assertNoViolations( violations );
 	}
 
 	@Test
@@ -256,7 +254,7 @@ public class ValidateConstructorParametersTest extends AbstractTCKTest {
 				parameterValues
 		);
 
-		assertNumberOfViolations( violations, 0 );
+		assertNoViolations( violations );
 
 		violations = getExecutableValidator().validateConstructorParameters(
 				constructor,
@@ -264,11 +262,12 @@ public class ValidateConstructorParametersTest extends AbstractTCKTest {
 				Extended.class
 		);
 
-		assertCorrectConstraintTypes( violations, Size.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( User.class )
-						.parameter( "lastName", 0 )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.constructor( User.class )
+								.parameter( "lastName", 0 )
+						)
 		);
 	}
 
@@ -286,7 +285,7 @@ public class ValidateConstructorParametersTest extends AbstractTCKTest {
 				parameterValues
 		);
 
-		assertNumberOfViolations( violations, 0 );
+		assertNoViolations( violations );
 
 		violations = getExecutableValidator().validateConstructorParameters(
 				constructor,
@@ -294,11 +293,12 @@ public class ValidateConstructorParametersTest extends AbstractTCKTest {
 				Extended.class
 		);
 
-		assertCorrectConstraintTypes( violations, MyCrossParameterConstraint.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( User.class )
-						.crossParameter()
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( MyCrossParameterConstraint.class )
+						.withPropertyPath( pathWith()
+								.constructor( User.class )
+								.crossParameter()
+						)
 		);
 	}
 
@@ -317,7 +317,7 @@ public class ValidateConstructorParametersTest extends AbstractTCKTest {
 				parameterValues
 		);
 
-		assertNumberOfViolations( violations, 0 );
+		assertNoViolations( violations );
 
 		violations = getExecutableValidator().validateConstructorParameters(
 				constructor,
@@ -326,17 +326,22 @@ public class ValidateConstructorParametersTest extends AbstractTCKTest {
 				Extended.class
 		);
 
-		assertCorrectConstraintTypes( violations, NotNull.class, Size.class, NotNull.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( User.class )
-						.parameter( "firstName", 0 ),
-				pathWith()
-						.constructor( User.class )
-						.parameter( "lastName", 1 ),
-				pathWith()
-						.constructor( User.class )
-						.parameter( "dateOfBirth", 2 )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.constructor( User.class )
+								.parameter( "firstName", 0 )
+						),
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.constructor( User.class )
+								.parameter( "lastName", 1 )
+						),
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.constructor( User.class )
+								.parameter( "dateOfBirth", 2 )
+						)
 		);
 	}
 
@@ -414,7 +419,9 @@ public class ValidateConstructorParametersTest extends AbstractTCKTest {
 				parameterValues
 		);
 
-		assertNumberOfViolations( violations, 1 );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class )
+		);
 
 		ConstraintViolation<OrderLine> violation = violations.iterator().next();
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ValidateConstructorReturnValueTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ValidateConstructorReturnValueTest.java
@@ -6,10 +6,10 @@
  */
 package org.hibernate.beanvalidation.tck.tests.methodvalidation;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintTypes;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
@@ -19,6 +19,7 @@ import java.util.Set;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.ValidationException;
+import javax.validation.constraints.Size;
 
 import org.hibernate.beanvalidation.tck.beanvalidation.Sections;
 import org.hibernate.beanvalidation.tck.tests.AbstractTCKTest;
@@ -75,13 +76,12 @@ public class ValidateConstructorReturnValueTest extends AbstractTCKTest {
 				returnValue
 		);
 
-		assertNumberOfViolations( violations, 1 );
-
-		assertCorrectConstraintTypes( violations, ValidCustomer.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( Customer.class )
-						.returnValue()
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( ValidCustomer.class )
+						.withPropertyPath( pathWith()
+								.constructor( Customer.class )
+								.returnValue()
+						)
 		);
 
 		ConstraintViolation<Customer> violation = violations.iterator().next();
@@ -104,16 +104,17 @@ public class ValidateConstructorReturnValueTest extends AbstractTCKTest {
 				returnValue
 		);
 
-		assertNumberOfViolations( violations, 2 );
-
-		assertCorrectConstraintTypes( violations, ValidCustomer.class, ValidBusinessCustomer.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( Customer.class )
-						.returnValue(),
-				pathWith()
-						.constructor( Customer.class )
-						.returnValue()
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( ValidCustomer.class )
+						.withPropertyPath( pathWith()
+								.constructor( Customer.class )
+								.returnValue()
+						),
+				violationOf( ValidBusinessCustomer.class )
+						.withPropertyPath( pathWith()
+								.constructor( Customer.class )
+								.returnValue()
+						)
 		);
 	}
 
@@ -128,16 +129,17 @@ public class ValidateConstructorReturnValueTest extends AbstractTCKTest {
 				returnValue
 		);
 
-		assertNumberOfViolations( violations, 2 );
-
-		assertCorrectConstraintTypes( violations, ValidCustomer.class, ValidCustomer.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( Customer.class )
-						.returnValue(),
-				pathWith()
-						.constructor( Customer.class )
-						.returnValue()
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( ValidCustomer.class )
+						.withPropertyPath( pathWith()
+								.constructor( Customer.class )
+								.returnValue()
+						),
+				violationOf( ValidCustomer.class )
+						.withPropertyPath( pathWith()
+								.constructor( Customer.class )
+								.returnValue()
+						)
 		);
 	}
 
@@ -152,7 +154,7 @@ public class ValidateConstructorReturnValueTest extends AbstractTCKTest {
 				returnValue
 		);
 
-		assertNumberOfViolations( violations, 0 );
+		assertNoViolations( violations );
 	}
 
 	@Test
@@ -166,7 +168,7 @@ public class ValidateConstructorReturnValueTest extends AbstractTCKTest {
 				returnValue
 		);
 
-		assertNumberOfViolations( violations, 0 );
+		assertNoViolations( violations );
 
 		violations = getExecutableValidator().validateConstructorReturnValue(
 				constructor,
@@ -174,11 +176,12 @@ public class ValidateConstructorReturnValueTest extends AbstractTCKTest {
 				Extended.class
 		);
 
-		assertCorrectConstraintTypes( violations, ValidCustomer.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( Customer.class )
-						.returnValue()
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( ValidCustomer.class )
+						.withPropertyPath( pathWith()
+								.constructor( Customer.class )
+								.returnValue()
+						)
 		);
 	}
 
@@ -193,7 +196,7 @@ public class ValidateConstructorReturnValueTest extends AbstractTCKTest {
 				returnValue
 		);
 
-		assertNumberOfViolations( violations, 0 );
+		assertNoViolations( violations );
 
 		violations = getExecutableValidator().validateConstructorReturnValue(
 				constructor,
@@ -202,14 +205,17 @@ public class ValidateConstructorReturnValueTest extends AbstractTCKTest {
 				Extended.class
 		);
 
-		assertCorrectConstraintTypes( violations, ValidCustomer.class, ValidBusinessCustomer.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.constructor( Customer.class )
-						.returnValue(),
-				pathWith()
-						.constructor( Customer.class )
-						.returnValue()
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( ValidCustomer.class )
+						.withPropertyPath( pathWith()
+								.constructor( Customer.class )
+								.returnValue()
+						),
+				violationOf( ValidBusinessCustomer.class )
+						.withPropertyPath( pathWith()
+								.constructor( Customer.class )
+								.returnValue()
+						)
 		);
 	}
 
@@ -287,7 +293,9 @@ public class ValidateConstructorReturnValueTest extends AbstractTCKTest {
 				createdObject
 		);
 
-		assertNumberOfViolations( violations, 1 );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class )
+		);
 
 		ConstraintViolation<Object> violation = violations.iterator().next();
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ValidateParametersTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ValidateParametersTest.java
@@ -6,10 +6,10 @@
  */
 package org.hibernate.beanvalidation.tck.tests.methodvalidation;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintTypes;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
@@ -32,10 +32,12 @@ import org.hibernate.beanvalidation.tck.tests.methodvalidation.model.OrderLine;
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.model.User;
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.model.User.Basic;
 import org.hibernate.beanvalidation.tck.tests.methodvalidation.model.User.Extended;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
+
 import org.testng.annotations.Test;
 
 /**
@@ -79,13 +81,12 @@ public class ValidateParametersTest extends AbstractTCKTest {
 				parameterValues
 		);
 
-		assertNumberOfViolations( violations, 1 );
-
-		assertCorrectConstraintTypes( violations, Size.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.parameter( "firstName", 0 )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "firstName", 0 )
+						)
 		);
 
 		ConstraintViolation<Object> violation = violations.iterator().next();
@@ -114,13 +115,12 @@ public class ValidateParametersTest extends AbstractTCKTest {
 				parameterValues
 		);
 
-		assertNumberOfViolations( violations, 1 );
-
-		assertCorrectConstraintTypes( violations, MyCrossParameterConstraint.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.crossParameter()
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( MyCrossParameterConstraint.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.crossParameter()
+						)
 		);
 
 		ConstraintViolation<Object> violation = violations.iterator().next();
@@ -143,16 +143,17 @@ public class ValidateParametersTest extends AbstractTCKTest {
 				parameterValues
 		);
 
-		assertNumberOfViolations( violations, 2 );
-
-		assertCorrectConstraintTypes( violations, NotNull.class, Size.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.parameter( "firstName", 0 ),
-				pathWith()
-						.method( methodName )
-						.parameter( "lastName", 1 )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "firstName", 0 )
+						),
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "lastName", 1 )
+						)
 		);
 	}
 
@@ -171,16 +172,17 @@ public class ValidateParametersTest extends AbstractTCKTest {
 				parameterValues
 		);
 
-		assertNumberOfViolations( violations, 2 );
-
-		assertCorrectConstraintTypes( violations, Pattern.class, Size.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.parameter( "firstName", 0 ),
-				pathWith()
-						.method( methodName )
-						.parameter( "firstName", 0 )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "firstName", 0 )
+						),
+				violationOf( Pattern.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "firstName", 0 )
+						)
 		);
 	}
 
@@ -199,16 +201,17 @@ public class ValidateParametersTest extends AbstractTCKTest {
 				parameterValues
 		);
 
-		assertNumberOfViolations( violations, 2 );
-
-		assertCorrectConstraintTypes( violations, Size.class, Size.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.parameter( "lastName", 0 ),
-				pathWith()
-						.method( methodName )
-						.parameter( "lastName", 0 )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "lastName", 0 )
+						),
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "lastName", 0 )
+						)
 		);
 	}
 
@@ -232,20 +235,17 @@ public class ValidateParametersTest extends AbstractTCKTest {
 				parameterValues
 		);
 
-		assertNumberOfViolations( violations, 2 );
-
-		assertCorrectConstraintTypes(
-				violations,
-				MyCrossParameterConstraint.class,
-				MyCrossParameterConstraint.class
-		);
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.crossParameter(),
-				pathWith()
-						.method( methodName )
-						.crossParameter()
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( MyCrossParameterConstraint.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.crossParameter()
+						),
+				violationOf( MyCrossParameterConstraint.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.crossParameter()
+						)
 		);
 	}
 
@@ -262,7 +262,7 @@ public class ValidateParametersTest extends AbstractTCKTest {
 				parameterValues
 		);
 
-		assertNumberOfViolations( violations, 0 );
+		assertNoViolations( violations );
 	}
 
 	@Test
@@ -280,7 +280,7 @@ public class ValidateParametersTest extends AbstractTCKTest {
 				parameterValues
 		);
 
-		assertNumberOfViolations( violations, 0 );
+		assertNoViolations( violations );
 
 		violations = getExecutableValidator().validateParameters(
 				object,
@@ -289,11 +289,12 @@ public class ValidateParametersTest extends AbstractTCKTest {
 				Extended.class
 		);
 
-		assertCorrectConstraintTypes( violations, Size.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.parameter( "lastName", 0 )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "lastName", 0 )
+						)
 		);
 	}
 
@@ -312,7 +313,7 @@ public class ValidateParametersTest extends AbstractTCKTest {
 				parameterValues
 		);
 
-		assertNumberOfViolations( violations, 0 );
+		assertNoViolations( violations );
 
 		violations = getExecutableValidator().validateParameters(
 				object,
@@ -321,11 +322,12 @@ public class ValidateParametersTest extends AbstractTCKTest {
 				Extended.class
 		);
 
-		assertCorrectConstraintTypes( violations, MyCrossParameterConstraint.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.crossParameter()
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( MyCrossParameterConstraint.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.crossParameter()
+						)
 		);
 	}
 
@@ -344,7 +346,7 @@ public class ValidateParametersTest extends AbstractTCKTest {
 				parameterValues
 		);
 
-		assertNumberOfViolations( violations, 0 );
+		assertNoViolations( violations );
 
 		violations = getExecutableValidator().validateParameters(
 				object,
@@ -354,17 +356,22 @@ public class ValidateParametersTest extends AbstractTCKTest {
 				Extended.class
 		);
 
-		assertCorrectConstraintTypes( violations, NotNull.class, Size.class, NotNull.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.parameter( "firstName", 0 ),
-				pathWith()
-						.method( methodName )
-						.parameter( "lastName", 1 ),
-				pathWith()
-						.method( methodName )
-						.parameter( "dateOfBirth", 2 )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "firstName", 0 )
+						),
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "lastName", 1 )
+						),
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.method( methodName )
+								.parameter( "dateOfBirth", 2 )
+						)
 		);
 	}
 
@@ -471,7 +478,9 @@ public class ValidateParametersTest extends AbstractTCKTest {
 				parameterValues
 		);
 
-		assertNumberOfViolations( violations, 1 );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class )
+		);
 
 		ConstraintViolation<Object> violation = violations.iterator().next();
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ValidateReturnValueTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/ValidateReturnValueTest.java
@@ -6,10 +6,10 @@
  */
 package org.hibernate.beanvalidation.tck.tests.methodvalidation;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintTypes;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
@@ -79,13 +79,12 @@ public class ValidateReturnValueTest extends AbstractTCKTest {
 				returnValue
 		);
 
-		assertNumberOfViolations( violations, 1 );
-
-		assertCorrectConstraintTypes( violations, Size.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.returnValue()
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+							   .method( methodName )
+							   .returnValue()
+						)
 		);
 
 		ConstraintViolation<Object> violation = violations.iterator().next();
@@ -112,16 +111,17 @@ public class ValidateReturnValueTest extends AbstractTCKTest {
 				returnValue
 		);
 
-		assertNumberOfViolations( violations, 2 );
-
-		assertCorrectConstraintTypes( violations, Pattern.class, Size.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.returnValue(),
-				pathWith()
-						.method( methodName )
-						.returnValue()
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+							   .method( methodName )
+							   .returnValue()
+						),
+				violationOf( Pattern.class )
+						.withPropertyPath( pathWith()
+							   .method( methodName )
+							   .returnValue()
+						)
 		);
 	}
 
@@ -140,16 +140,17 @@ public class ValidateReturnValueTest extends AbstractTCKTest {
 				returnValue
 		);
 
-		assertNumberOfViolations( violations, 2 );
-
-		assertCorrectConstraintTypes( violations, Size.class, Size.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.returnValue(),
-				pathWith()
-						.method( methodName )
-						.returnValue()
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+							   .method( methodName )
+							   .returnValue()
+						),
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+							   .method( methodName )
+							   .returnValue()
+						)
 		);
 	}
 
@@ -166,7 +167,7 @@ public class ValidateReturnValueTest extends AbstractTCKTest {
 				returnValue
 		);
 
-		assertNumberOfViolations( violations, 0 );
+		assertNoViolations( violations );
 	}
 
 	@Test
@@ -184,7 +185,7 @@ public class ValidateReturnValueTest extends AbstractTCKTest {
 				returnValue
 		);
 
-		assertNumberOfViolations( violations, 0 );
+		assertNoViolations( violations );
 
 		violations = getExecutableValidator().validateReturnValue(
 				object,
@@ -193,11 +194,12 @@ public class ValidateReturnValueTest extends AbstractTCKTest {
 				Extended.class
 		);
 
-		assertCorrectConstraintTypes( violations, Size.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.returnValue()
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+							   .method( methodName )
+							   .returnValue()
+						)
 		);
 	}
 
@@ -216,7 +218,7 @@ public class ValidateReturnValueTest extends AbstractTCKTest {
 				returnValue
 		);
 
-		assertNumberOfViolations( violations, 0 );
+		assertNoViolations( violations );
 
 		violations = getExecutableValidator().validateReturnValue(
 				object,
@@ -225,15 +227,17 @@ public class ValidateReturnValueTest extends AbstractTCKTest {
 				Basic.class,
 				Extended.class
 		);
-
-		assertCorrectConstraintTypes( violations, Size.class, Pattern.class );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.method( methodName )
-						.returnValue(),
-				pathWith()
-						.method( methodName )
-						.returnValue()
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class )
+						.withPropertyPath( pathWith()
+							   .method( methodName )
+							   .returnValue()
+						),
+				violationOf( Pattern.class )
+						.withPropertyPath( pathWith()
+							   .method( methodName )
+							   .returnValue()
+						)
 		);
 	}
 
@@ -325,12 +329,19 @@ public class ValidateReturnValueTest extends AbstractTCKTest {
 				returnValue
 		);
 
-		assertNumberOfViolations( violations, 1 );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class )
+						.withInvalidValue( "foo" )
+						.withPropertyPath( pathWith()
+							   .method( methodName )
+							   .returnValue()
+								.property( "name" )
+						)
+		);
 
 		ConstraintViolation<Object> violation = violations.iterator().next();
 
 		assertEquals( violation.getLeafBean(), returnValue );
-		assertEquals( violation.getInvalidValue(), "foo" );
 		assertNull( violation.getExecutableParameters() );
 		assertEquals( violation.getExecutableReturnValue(), returnValue );
 	}

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/parameternameprovider/DefaultParameterNameProviderTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/parameternameprovider/DefaultParameterNameProviderTest.java
@@ -6,9 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.methodvalidation.parameternameprovider;
 
-import static org.hibernate.beanvalidation.tck.util.TestUtil.asSet;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
-import static org.hibernate.beanvalidation.tck.util.TestUtil.getParameterNames;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
@@ -20,6 +20,7 @@ import java.util.Set;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.ParameterNameProvider;
+import javax.validation.constraints.NotNull;
 
 import org.hibernate.beanvalidation.tck.beanvalidation.Sections;
 import org.hibernate.beanvalidation.tck.tests.AbstractTCKTest;
@@ -55,12 +56,18 @@ public class DefaultParameterNameProviderTest extends AbstractTCKTest {
 
 		Set<ConstraintViolation<Object>> constraintViolations = getExecutableValidator()
 				.validateParameters( object, method, parameters );
-		assertNumberOfViolations( constraintViolations, 2 );
-
-		Set<String> actualParameterNames = getParameterNames( constraintViolations );
-		Set<String> expectedParameterNames = asSet( "firstName", "lastName" );
-
-		assertEquals( actualParameterNames, expectedParameterNames );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+							   .method( "setNames" )
+							   .parameter( "firstName", 0 )
+						),
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+							   .method( "setNames" )
+							   .parameter( "lastName", 1 )
+						)
+		);
 	}
 
 	@Test
@@ -75,12 +82,23 @@ public class DefaultParameterNameProviderTest extends AbstractTCKTest {
 
 		Set<ConstraintViolation<User>> constraintViolations = getExecutableValidator()
 				.validateConstructorParameters( constructor, parameters );
-		assertNumberOfViolations( constraintViolations, 3 );
-
-		Set<String> actualParameterNames = getParameterNames( constraintViolations );
-		Set<String> expectedParameterNames = asSet( "firstName", "lastName", "dateOfBirth" );
-
-		assertEquals( actualParameterNames, expectedParameterNames );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+							   .constructor( User.class )
+							   .parameter( "firstName", 0 )
+						),
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+							   .constructor( User.class )
+							   .parameter( "lastName", 1 )
+						),
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+							   .constructor( User.class )
+							   .parameter( "dateOfBirth", 2 )
+						)
+		);
 	}
 
 	@Test

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/parameternameprovider/ParameterNameProviderTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/methodvalidation/parameternameprovider/ParameterNameProviderTest.java
@@ -6,10 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.methodvalidation.parameternameprovider;
 
-import static org.hibernate.beanvalidation.tck.util.TestUtil.asSet;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
-import static org.hibernate.beanvalidation.tck.util.TestUtil.getParameterNames;
-import static org.testng.Assert.assertEquals;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.fail;
 
@@ -20,15 +19,18 @@ import javax.validation.ConstraintViolation;
 import javax.validation.ValidationException;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
+import javax.validation.constraints.NotNull;
 import javax.validation.executable.ExecutableValidator;
 
 import org.hibernate.beanvalidation.tck.beanvalidation.Sections;
 import org.hibernate.beanvalidation.tck.tests.AbstractTCKTest;
 import org.hibernate.beanvalidation.tck.util.TestUtil;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
+
 import org.testng.annotations.Test;
 
 /**
@@ -103,11 +105,17 @@ public class ParameterNameProviderTest extends AbstractTCKTest {
 				method,
 				parameters
 		);
-		assertNumberOfViolations( constraintViolations, 2 );
-
-		Set<String> actualParameterNames = getParameterNames( constraintViolations );
-		Set<String> expectedParameterNames = asSet( "param0", "param1" );
-
-		assertEquals( actualParameterNames, expectedParameterNames );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+							   .method( "setNames" )
+							   .parameter( "param0", 0 )
+						),
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+							   .method( "setNames" )
+							   .parameter( "param1", 1 )
+						)
+		);
 	}
 }

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/time/ClockProviderFutureOrPresentTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/time/ClockProviderFutureOrPresentTest.java
@@ -6,9 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.time;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -17,6 +17,7 @@ import java.util.Set;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
+import javax.validation.constraints.FutureOrPresent;
 
 import org.hibernate.beanvalidation.tck.beanvalidation.Sections;
 import org.hibernate.beanvalidation.tck.tests.AbstractTCKTest;
@@ -51,7 +52,7 @@ public class ClockProviderFutureOrPresentTest extends AbstractTCKTest {
 
 		Validator validator = TestUtil.getValidatorUnderTest();
 
-		assertNumberOfViolations( validator.validate( dummy ), 0 );
+		assertNoViolations( validator.validate( dummy ) );
 
 		FixedClockProvider clockProvider = new FixedClockProvider(
 				ZonedDateTime.of(
@@ -65,34 +66,20 @@ public class ClockProviderFutureOrPresentTest extends AbstractTCKTest {
 		validator = validatorFactory.getValidator();
 
 		Set<ConstraintViolation<FutureOrPresentDummyEntity>> violations = validator.validate( dummy );
-		assertNumberOfViolations( violations, 13 );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.property( "date" ),
-				pathWith()
-						.property( "calendar" ),
-				pathWith()
-						.property( "instant" ),
-				pathWith()
-						.property( "hijrahDate" ),
-				pathWith()
-						.property( "japaneseDate" ),
-				pathWith()
-						.property( "localDate" ),
-				pathWith()
-						.property( "localDateTime" ),
-				pathWith()
-						.property( "minguoDate" ),
-				pathWith()
-						.property( "offsetDateTime" ),
-				pathWith()
-						.property( "thaiBuddhistDate" ),
-				pathWith()
-						.property( "year" ),
-				pathWith()
-						.property( "yearMonth" ),
-				pathWith()
-						.property( "zonedDateTime" )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( FutureOrPresent.class ).withProperty( "date" ),
+				violationOf( FutureOrPresent.class ).withProperty( "calendar" ),
+				violationOf( FutureOrPresent.class ).withProperty( "instant" ),
+				violationOf( FutureOrPresent.class ).withProperty( "hijrahDate" ),
+				violationOf( FutureOrPresent.class ).withProperty( "japaneseDate" ),
+				violationOf( FutureOrPresent.class ).withProperty( "localDate" ),
+				violationOf( FutureOrPresent.class ).withProperty( "localDateTime" ),
+				violationOf( FutureOrPresent.class ).withProperty( "minguoDate" ),
+				violationOf( FutureOrPresent.class ).withProperty( "offsetDateTime" ),
+				violationOf( FutureOrPresent.class ).withProperty( "thaiBuddhistDate" ),
+				violationOf( FutureOrPresent.class ).withProperty( "year" ),
+				violationOf( FutureOrPresent.class ).withProperty( "yearMonth" ),
+				violationOf( FutureOrPresent.class ).withProperty( "zonedDateTime" )
 		);
 	}
 
@@ -107,7 +94,7 @@ public class ClockProviderFutureOrPresentTest extends AbstractTCKTest {
 				.buildValidatorFactory();
 		Validator validator = validatorFactory.getValidator();
 
-		assertNumberOfViolations( validator.validate( dummy ), 0 );
+		assertNoViolations( validator.validate( dummy ) );
 
 		clockProvider = new FixedClockProvider( ZonedDateTime.of( 2016, 8, 17, 17, 45, 0, 0, TZ_BERLIN ) );
 		validatorFactory = TestUtil.getConfigurationUnderTest()
@@ -116,14 +103,10 @@ public class ClockProviderFutureOrPresentTest extends AbstractTCKTest {
 		validator = validatorFactory.getValidator();
 
 		Set<ConstraintViolation<FutureOrPresentRelativePartialDummyEntity>> violations = validator.validate( dummy );
-		assertNumberOfViolations( violations, 3 );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.property( "localTime" ),
-				pathWith()
-						.property( "monthDay" ),
-				pathWith()
-						.property( "offsetTime" )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( FutureOrPresent.class ).withProperty( "localTime" ),
+				violationOf( FutureOrPresent.class ).withProperty( "monthDay" ),
+				violationOf( FutureOrPresent.class ).withProperty( "offsetTime" )
 		);
 	}
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/time/ClockProviderFutureTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/time/ClockProviderFutureTest.java
@@ -6,9 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.time;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -17,6 +17,7 @@ import java.util.Set;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
+import javax.validation.constraints.Future;
 
 import org.hibernate.beanvalidation.tck.beanvalidation.Sections;
 import org.hibernate.beanvalidation.tck.tests.AbstractTCKTest;
@@ -51,7 +52,7 @@ public class ClockProviderFutureTest extends AbstractTCKTest {
 
 		Validator validator = TestUtil.getValidatorUnderTest();
 
-		assertNumberOfViolations( validator.validate( dummy ), 0 );
+		assertNoViolations( validator.validate( dummy ) );
 
 		FixedClockProvider clockProvider = new FixedClockProvider(
 				ZonedDateTime.of(
@@ -65,34 +66,20 @@ public class ClockProviderFutureTest extends AbstractTCKTest {
 		validator = validatorFactory.getValidator();
 
 		Set<ConstraintViolation<FutureDummyEntity>> violations = validator.validate( dummy );
-		assertNumberOfViolations( violations, 13 );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.property( "date" ),
-				pathWith()
-						.property( "calendar" ),
-				pathWith()
-						.property( "instant" ),
-				pathWith()
-						.property( "hijrahDate" ),
-				pathWith()
-						.property( "japaneseDate" ),
-				pathWith()
-						.property( "localDate" ),
-				pathWith()
-						.property( "localDateTime" ),
-				pathWith()
-						.property( "minguoDate" ),
-				pathWith()
-						.property( "offsetDateTime" ),
-				pathWith()
-						.property( "thaiBuddhistDate" ),
-				pathWith()
-						.property( "year" ),
-				pathWith()
-						.property( "yearMonth" ),
-				pathWith()
-						.property( "zonedDateTime" )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Future.class ).withProperty( "date" ),
+				violationOf( Future.class ).withProperty( "calendar" ),
+				violationOf( Future.class ).withProperty( "instant" ),
+				violationOf( Future.class ).withProperty( "hijrahDate" ),
+				violationOf( Future.class ).withProperty( "japaneseDate" ),
+				violationOf( Future.class ).withProperty( "localDate" ),
+				violationOf( Future.class ).withProperty( "localDateTime" ),
+				violationOf( Future.class ).withProperty( "minguoDate" ),
+				violationOf( Future.class ).withProperty( "offsetDateTime" ),
+				violationOf( Future.class ).withProperty( "thaiBuddhistDate" ),
+				violationOf( Future.class ).withProperty( "year" ),
+				violationOf( Future.class ).withProperty( "yearMonth" ),
+				violationOf( Future.class ).withProperty( "zonedDateTime" )
 		);
 	}
 
@@ -107,7 +94,7 @@ public class ClockProviderFutureTest extends AbstractTCKTest {
 				.buildValidatorFactory();
 		Validator validator = validatorFactory.getValidator();
 
-		assertNumberOfViolations( validator.validate( dummy ), 0 );
+		assertNoViolations( validator.validate( dummy ) );
 
 		clockProvider = new FixedClockProvider( ZonedDateTime.of( 2016, 8, 17, 17, 45, 0, 0, TZ_BERLIN ) );
 		validatorFactory = TestUtil.getConfigurationUnderTest()
@@ -116,14 +103,10 @@ public class ClockProviderFutureTest extends AbstractTCKTest {
 		validator = validatorFactory.getValidator();
 
 		Set<ConstraintViolation<FutureRelativePartialDummyEntity>> violations = validator.validate( dummy );
-		assertNumberOfViolations( violations, 3 );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.property( "localTime" ),
-				pathWith()
-						.property( "monthDay" ),
-				pathWith()
-						.property( "offsetTime" )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Future.class ).withProperty( "localTime" ),
+				violationOf( Future.class ).withProperty( "monthDay" ),
+				violationOf( Future.class ).withProperty( "offsetTime" )
 		);
 	}
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/time/ClockProviderPastOrPresentTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/time/ClockProviderPastOrPresentTest.java
@@ -6,9 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.time;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -20,6 +20,7 @@ import java.util.TimeZone;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
+import javax.validation.constraints.PastOrPresent;
 
 import org.hibernate.beanvalidation.tck.beanvalidation.Sections;
 import org.hibernate.beanvalidation.tck.tests.AbstractTCKTest;
@@ -55,7 +56,7 @@ public class ClockProviderPastOrPresentTest extends AbstractTCKTest {
 
 		Validator validator = TestUtil.getValidatorUnderTest();
 
-		assertNumberOfViolations( validator.validate( dummy ), 0 );
+		assertNoViolations( validator.validate( dummy ) );
 
 		FixedClockProvider clockProvider = new FixedClockProvider( ZonedDateTime.of( 1984, 2, 15, 4, 0, 0, 0, TZ_BERLIN ) );
 		ValidatorFactory validatorFactory = TestUtil.getConfigurationUnderTest()
@@ -64,34 +65,20 @@ public class ClockProviderPastOrPresentTest extends AbstractTCKTest {
 		validator = validatorFactory.getValidator();
 
 		Set<ConstraintViolation<PastOrPresentDummyEntity>> violations = validator.validate( dummy );
-		assertNumberOfViolations( violations, 13 );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.property( "date" ),
-				pathWith()
-						.property( "calendar" ),
-				pathWith()
-						.property( "instant" ),
-				pathWith()
-						.property( "hijrahDate" ),
-				pathWith()
-						.property( "japaneseDate" ),
-				pathWith()
-						.property( "localDate" ),
-				pathWith()
-						.property( "localDateTime" ),
-				pathWith()
-						.property( "minguoDate" ),
-				pathWith()
-						.property( "offsetDateTime" ),
-				pathWith()
-						.property( "thaiBuddhistDate" ),
-				pathWith()
-						.property( "year" ),
-				pathWith()
-						.property( "yearMonth" ),
-				pathWith()
-						.property( "zonedDateTime" )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( PastOrPresent.class ).withProperty( "date" ),
+				violationOf( PastOrPresent.class ).withProperty( "calendar" ),
+				violationOf( PastOrPresent.class ).withProperty( "instant" ),
+				violationOf( PastOrPresent.class ).withProperty( "hijrahDate" ),
+				violationOf( PastOrPresent.class ).withProperty( "japaneseDate" ),
+				violationOf( PastOrPresent.class ).withProperty( "localDate" ),
+				violationOf( PastOrPresent.class ).withProperty( "localDateTime" ),
+				violationOf( PastOrPresent.class ).withProperty( "minguoDate" ),
+				violationOf( PastOrPresent.class ).withProperty( "offsetDateTime" ),
+				violationOf( PastOrPresent.class ).withProperty( "thaiBuddhistDate" ),
+				violationOf( PastOrPresent.class ).withProperty( "year" ),
+				violationOf( PastOrPresent.class ).withProperty( "yearMonth" ),
+				violationOf( PastOrPresent.class ).withProperty( "zonedDateTime" )
 		);
 	}
 
@@ -111,7 +98,7 @@ public class ClockProviderPastOrPresentTest extends AbstractTCKTest {
 				.buildValidatorFactory();
 		Validator validator = validatorFactory.getValidator();
 
-		assertNumberOfViolations( validator.validate( dummy ), 0 );
+		assertNoViolations( validator.validate( dummy ) );
 
 		clockProvider = new FixedClockProvider( ZonedDateTime.of( 2014, 4, 4, 9, 45, 0, 0, TZ_BERLIN ) );
 		validatorFactory = TestUtil.getConfigurationUnderTest()
@@ -120,14 +107,10 @@ public class ClockProviderPastOrPresentTest extends AbstractTCKTest {
 		validator = validatorFactory.getValidator();
 
 		Set<ConstraintViolation<PastOrPresentRelativePartialDummyEntity>> violations = validator.validate( dummy );
-		assertNumberOfViolations( violations, 3 );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.property( "localTime" ),
-				pathWith()
-						.property( "monthDay" ),
-				pathWith()
-						.property( "offsetTime" )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( PastOrPresent.class ).withProperty( "localTime" ),
+				violationOf( PastOrPresent.class ).withProperty( "monthDay" ),
+				violationOf( PastOrPresent.class ).withProperty( "offsetTime" )
 		);
 	}
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/time/ClockProviderPastTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/time/ClockProviderPastTest.java
@@ -6,9 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.time;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -20,6 +20,7 @@ import java.util.TimeZone;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
+import javax.validation.constraints.Past;
 
 import org.hibernate.beanvalidation.tck.beanvalidation.Sections;
 import org.hibernate.beanvalidation.tck.tests.AbstractTCKTest;
@@ -55,7 +56,7 @@ public class ClockProviderPastTest extends AbstractTCKTest {
 
 		Validator validator = TestUtil.getValidatorUnderTest();
 
-		assertNumberOfViolations( validator.validate( dummy ), 0 );
+		assertNoViolations( validator.validate( dummy ) );
 
 		FixedClockProvider clockProvider = new FixedClockProvider( ZonedDateTime.of( 1984, 2, 15, 4, 0, 0, 0, TZ_BERLIN ) );
 		ValidatorFactory validatorFactory = TestUtil.getConfigurationUnderTest()
@@ -64,34 +65,20 @@ public class ClockProviderPastTest extends AbstractTCKTest {
 		validator = validatorFactory.getValidator();
 
 		Set<ConstraintViolation<PastDummyEntity>> violations = validator.validate( dummy );
-		assertNumberOfViolations( violations, 13 );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.property( "date" ),
-				pathWith()
-						.property( "calendar" ),
-				pathWith()
-						.property( "instant" ),
-				pathWith()
-						.property( "hijrahDate" ),
-				pathWith()
-						.property( "japaneseDate" ),
-				pathWith()
-						.property( "localDate" ),
-				pathWith()
-						.property( "localDateTime" ),
-				pathWith()
-						.property( "minguoDate" ),
-				pathWith()
-						.property( "offsetDateTime" ),
-				pathWith()
-						.property( "thaiBuddhistDate" ),
-				pathWith()
-						.property( "year" ),
-				pathWith()
-						.property( "yearMonth" ),
-				pathWith()
-						.property( "zonedDateTime" )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Past.class ).withProperty( "date" ),
+				violationOf( Past.class ).withProperty( "calendar" ),
+				violationOf( Past.class ).withProperty( "instant" ),
+				violationOf( Past.class ).withProperty( "hijrahDate" ),
+				violationOf( Past.class ).withProperty( "japaneseDate" ),
+				violationOf( Past.class ).withProperty( "localDate" ),
+				violationOf( Past.class ).withProperty( "localDateTime" ),
+				violationOf( Past.class ).withProperty( "minguoDate" ),
+				violationOf( Past.class ).withProperty( "offsetDateTime" ),
+				violationOf( Past.class ).withProperty( "thaiBuddhistDate" ),
+				violationOf( Past.class ).withProperty( "year" ),
+				violationOf( Past.class ).withProperty( "yearMonth" ),
+				violationOf( Past.class ).withProperty( "zonedDateTime" )
 		);
 	}
 
@@ -111,7 +98,7 @@ public class ClockProviderPastTest extends AbstractTCKTest {
 				.buildValidatorFactory();
 		Validator validator = validatorFactory.getValidator();
 
-		assertNumberOfViolations( validator.validate( dummy ), 0 );
+		assertNoViolations( validator.validate( dummy ) );
 
 		clockProvider = new FixedClockProvider( ZonedDateTime.of( 2014, 4, 4, 9, 45, 0, 0, TZ_BERLIN ) );
 		validatorFactory = TestUtil.getConfigurationUnderTest()
@@ -120,14 +107,10 @@ public class ClockProviderPastTest extends AbstractTCKTest {
 		validator = validatorFactory.getValidator();
 
 		Set<ConstraintViolation<PastRelativePartialDummyEntity>> violations = validator.validate( dummy );
-		assertNumberOfViolations( violations, 3 );
-		assertThat( violations ).containsOnlyPaths(
-				pathWith()
-						.property( "localTime" ),
-				pathWith()
-						.property( "monthDay" ),
-				pathWith()
-						.property( "offsetTime" )
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Past.class ).withProperty( "localTime" ),
+				violationOf( Past.class ).withProperty( "monthDay" ),
+				violationOf( Past.class ).withProperty( "offsetTime" )
 		);
 	}
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/time/ClockProviderTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/time/ClockProviderTest.java
@@ -10,7 +10,7 @@ import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
 import static org.testng.Assert.assertNotNull;
@@ -102,7 +102,7 @@ public class ClockProviderTest extends AbstractTCKTest {
 
 		person.setBirthday( Instant.now().minus( Duration.ofDays( 15 ) ) );
 		Set<ConstraintViolation<Person>> constraintViolations = validator.validate( person );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		person.setBirthday( Instant.now().plus( Duration.ofDays( 15 ) ) );
 		constraintViolations = validator.validate( person );
@@ -119,7 +119,7 @@ public class ClockProviderTest extends AbstractTCKTest {
 
 		person.setBirthday( Instant.now().plus( Duration.ofDays( 15 ) ) );
 		constraintViolations = validator.validate( person );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		person.setBirthday( Instant.now().plus( Duration.ofDays( 90 ) ) );
 		constraintViolations = validator.validate( person );
@@ -165,7 +165,7 @@ public class ClockProviderTest extends AbstractTCKTest {
 				.getValidator();
 
 		constraintViolations = validator.validate( person );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	private static void checkClockProviderHasDefaultProperties(ClockProvider clockProvider) {

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/traversableresolver/TraversableResolverTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/traversableresolver/TraversableResolverTest.java
@@ -7,7 +7,7 @@
 package org.hibernate.beanvalidation.tck.tests.traversableresolver;
 
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.RETURN_VALUE_NODE_NAME;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertSame;
@@ -428,7 +428,7 @@ public class TraversableResolverTest extends AbstractTCKTest {
 
 		Person person = new Person();
 		Set<ConstraintViolation<Person>> constraintViolations = validator.validate( person );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	@Test

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/GetterDefinitionTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/GetterDefinitionTest.java
@@ -6,7 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.validation;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintTypes;
+
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.util.Set;
 
@@ -42,7 +44,9 @@ public class GetterDefinitionTest extends AbstractTCKTest {
 		Shipment shipment = new Shipment();
 
 		Set<ConstraintViolation<Shipment>> constraintViolations = getValidator().validateProperty( shipment, "id" );
-		assertCorrectConstraintTypes( constraintViolations, NotNull.class );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+		);
 	}
 
 	@Test
@@ -51,6 +55,8 @@ public class GetterDefinitionTest extends AbstractTCKTest {
 		Shipment shipment = new Shipment();
 
 		Set<ConstraintViolation<Shipment>> constraintViolations = getValidator().validateProperty( shipment, "shipped" );
-		assertCorrectConstraintTypes( constraintViolations, AssertTrue.class );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( AssertTrue.class )
+		);
 	}
 }

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/PropertyPathTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/PropertyPathTest.java
@@ -11,7 +11,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.BEAN_NODE_NAME;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.CROSS_PARAMETER_NODE_NAME;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.RETURN_VALUE_NODE_NAME;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.asSet;
 import static org.hibernate.beanvalidation.tck.util.TestUtil.getConstraintViolationForParameter;
 import static org.testng.Assert.assertEquals;
@@ -48,6 +49,9 @@ import javax.validation.Path.PropertyNode;
 import javax.validation.Path.ReturnValueNode;
 import javax.validation.Payload;
 import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.validation.executable.ExecutableValidator;
 
 import org.hibernate.beanvalidation.tck.beanvalidation.Sections;
@@ -112,7 +116,9 @@ public class PropertyPathTest extends AbstractTCKTest {
 	})
 	public void testPropertyPathWithConstraintViolationForRootObject() {
 		Set<ConstraintViolation<VerySpecialClass>> constraintViolations = getValidator().validate( new VerySpecialClass() );
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Special.class )
+		);
 		ConstraintViolation<VerySpecialClass> constraintViolation = constraintViolations.iterator()
 				.next();
 
@@ -143,7 +149,9 @@ public class PropertyPathTest extends AbstractTCKTest {
 		Engine engine = new Engine();
 		engine.setSerialNumber( "ABCDEFGH1234" );
 		Set<ConstraintViolation<Engine>> constraintViolations = getValidator().validate( engine );
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Pattern.class )
+		);
 
 		ConstraintViolation<Engine> constraintViolation = constraintViolations.iterator().next();
 
@@ -250,7 +258,9 @@ public class PropertyPathTest extends AbstractTCKTest {
 		Integer id = db.addActor( morgan );
 
 		Set<ConstraintViolation<ActorDB>> constraintViolations = getValidator().validate( db );
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+		);
 
 		ConstraintViolation<ActorDB> constraintViolation = constraintViolations.iterator().next();
 
@@ -283,7 +293,9 @@ public class PropertyPathTest extends AbstractTCKTest {
 		customer.addOrder( order );
 
 		Set<ConstraintViolation<Customer>> constraintViolations = getValidator().validate( customer );
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+		);
 
 		ConstraintViolation<Customer> constraintViolation = constraintViolations.iterator().next();
 		Iterator<Path.Node> nodeIter = constraintViolation.getPropertyPath().iterator();
@@ -333,7 +345,10 @@ public class PropertyPathTest extends AbstractTCKTest {
 		);
 
 		//then
-		assertNumberOfViolations( constraintViolations, 2 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class ),
+				violationOf( NotNull.class )
+		);
 
 		Iterator<Path.Node> nodeIter = getConstraintViolationForParameter(
 				constraintViolations,
@@ -415,7 +430,10 @@ public class PropertyPathTest extends AbstractTCKTest {
 		);
 
 		//then
-		assertNumberOfViolations( constraintViolations, 2 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class ),
+				violationOf( NotNull.class )
+		);
 
 		Iterator<Path.Node> nodeIter = getConstraintViolationForParameter(
 				constraintViolations,
@@ -475,7 +493,9 @@ public class PropertyPathTest extends AbstractTCKTest {
 		);
 
 		//then
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+		);
 		Iterator<Path.Node> nodeIter = constraintViolations.iterator().next().getPropertyPath().iterator();
 
 		assertTrue( nodeIter.hasNext() );
@@ -523,7 +543,9 @@ public class PropertyPathTest extends AbstractTCKTest {
 		);
 
 		//then
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( ActorLikesGenre.class )
+		);
 		Iterator<Path.Node> nodeIter = constraintViolations.iterator().next().getPropertyPath().iterator();
 
 		assertTrue( nodeIter.hasNext() );
@@ -573,7 +595,10 @@ public class PropertyPathTest extends AbstractTCKTest {
 		);
 
 		//then
-		assertNumberOfViolations( constraintViolations, 2 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class ),
+				violationOf( NotNull.class )
+		);
 
 		Iterator<Path.Node> nodeIter = getConstraintViolationForParameter(
 				constraintViolations,
@@ -750,7 +775,10 @@ public class PropertyPathTest extends AbstractTCKTest {
 		);
 
 		//then
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( ValidMovieStudio.class )
+		);
+
 		Iterator<Path.Node> nodeIter = constraintViolations.iterator().next().getPropertyPath().iterator();
 
 		assertTrue( nodeIter.hasNext() );
@@ -798,7 +826,9 @@ public class PropertyPathTest extends AbstractTCKTest {
 		);
 
 		//then
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+		);
 
 		Iterator<Path.Node> nodeIter = constraintViolations.iterator()
 				.next()
@@ -858,7 +888,9 @@ public class PropertyPathTest extends AbstractTCKTest {
 		);
 
 		//then
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+		);
 
 		Iterator<Path.Node> nodeIter = constraintViolations.iterator()
 				.next()
@@ -918,7 +950,9 @@ public class PropertyPathTest extends AbstractTCKTest {
 		);
 
 		//then
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+		);
 
 		Iterator<Path.Node> nodeIter = constraintViolations.iterator()
 				.next()
@@ -974,7 +1008,9 @@ public class PropertyPathTest extends AbstractTCKTest {
 		);
 
 		//then
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+		);
 
 		Iterator<Path.Node> nodeIter = constraintViolations.iterator()
 				.next()
@@ -1034,7 +1070,9 @@ public class PropertyPathTest extends AbstractTCKTest {
 		);
 
 		//then
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+		);
 
 		Iterator<Path.Node> nodeIter = constraintViolations.iterator()
 				.next()
@@ -1080,7 +1118,9 @@ public class PropertyPathTest extends AbstractTCKTest {
 		);
 
 		//then
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+		);
 
 		Iterator<Path.Node> nodeIter = constraintViolations.iterator()
 				.next()
@@ -1136,7 +1176,9 @@ public class PropertyPathTest extends AbstractTCKTest {
 		);
 
 		//then
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+		);
 
 		Iterator<Path.Node> nodeIter = constraintViolations.iterator()
 				.next()
@@ -1192,7 +1234,9 @@ public class PropertyPathTest extends AbstractTCKTest {
 		);
 
 		//then
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+		);
 
 		Iterator<Path.Node> nodeIter = constraintViolations.iterator()
 				.next()
@@ -1244,7 +1288,9 @@ public class PropertyPathTest extends AbstractTCKTest {
 		);
 
 		//then
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+		);
 
 		Iterator<Path.Node> nodeIter = constraintViolations.iterator()
 				.next()
@@ -1300,7 +1346,9 @@ public class PropertyPathTest extends AbstractTCKTest {
 		);
 
 		//then
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+		);
 
 		Iterator<Path.Node> nodeIter = constraintViolations.iterator()
 				.next()
@@ -1346,7 +1394,9 @@ public class PropertyPathTest extends AbstractTCKTest {
 		);
 
 		//then
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+		);
 
 		Iterator<Path.Node> nodeIter = constraintViolations.iterator()
 				.next()
@@ -1397,7 +1447,9 @@ public class PropertyPathTest extends AbstractTCKTest {
 		);
 
 		//then
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+		);
 
 		Iterator<Path.Node> nodeIter = constraintViolations.iterator()
 				.next()
@@ -1448,7 +1500,9 @@ public class PropertyPathTest extends AbstractTCKTest {
 		);
 
 		//then
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+		);
 
 		Iterator<Path.Node> nodeIter = constraintViolations.iterator()
 				.next()
@@ -1495,7 +1549,9 @@ public class PropertyPathTest extends AbstractTCKTest {
 		);
 
 		//then
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+		);
 
 		Iterator<Path.Node> nodeIter = constraintViolations.iterator()
 				.next()
@@ -1546,7 +1602,9 @@ public class PropertyPathTest extends AbstractTCKTest {
 		);
 
 		//then
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+		);
 
 		Iterator<Path.Node> nodeIter = constraintViolations.iterator()
 				.next()
@@ -1589,7 +1647,9 @@ public class PropertyPathTest extends AbstractTCKTest {
 		);
 
 		//then
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+		);
 
 		Iterator<Path.Node> nodeIter = constraintViolations.iterator()
 				.next()
@@ -1612,7 +1672,9 @@ public class PropertyPathTest extends AbstractTCKTest {
 	@SpecAssertion(section = Sections.VALIDATIONAPI_CONSTRAINTVIOLATION, id = "s")
 	public void testPassingWrongTypeToAsOnBeanNodeCausesClassCastException() {
 		Set<ConstraintViolation<VerySpecialClass>> constraintViolations = getValidator().validate( new VerySpecialClass() );
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Special.class )
+		);
 		ConstraintViolation<VerySpecialClass> constraintViolation = constraintViolations.iterator().next();
 
 		Iterator<Path.Node> nodeIter = constraintViolation.getPropertyPath().iterator();
@@ -1641,7 +1703,10 @@ public class PropertyPathTest extends AbstractTCKTest {
 		);
 
 		//then
-		assertNumberOfViolations( constraintViolations, 2 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class ),
+				violationOf( NotNull.class )
+		);
 
 		Iterator<Path.Node> nodeIter = getConstraintViolationForParameter(
 				constraintViolations,
@@ -1673,7 +1738,10 @@ public class PropertyPathTest extends AbstractTCKTest {
 		);
 
 		//then
-		assertNumberOfViolations( constraintViolations, 2 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class ),
+				violationOf( NotNull.class )
+		);
 
 		Iterator<Path.Node> nodeIter = getConstraintViolationForParameter(
 				constraintViolations,
@@ -1702,7 +1770,9 @@ public class PropertyPathTest extends AbstractTCKTest {
 		// container element node
 		Set<ConstraintViolation<MovieProduction>> constraintViolations = getValidator().validate( MovieProduction.invalidMapKey() );
 
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotBlank.class )
+		);
 		ConstraintViolation<MovieProduction> constraintViolation = constraintViolations.iterator().next();
 
 		Iterator<Path.Node> nodeIter = constraintViolation.getPropertyPath().iterator();
@@ -1728,7 +1798,9 @@ public class PropertyPathTest extends AbstractTCKTest {
 		// property node
 		constraintViolations = getValidator().validate( MovieProduction.invalidCascading() );
 
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotBlank.class )
+		);
 		constraintViolation = constraintViolations.iterator().next();
 
 		nodeIter = constraintViolation.getPropertyPath().iterator();
@@ -1754,7 +1826,9 @@ public class PropertyPathTest extends AbstractTCKTest {
 		// bean node
 		constraintViolations = getValidator().validate( MovieProduction.invalidExecutiveProducer() );
 
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( ValidExecutiveProducer.class )
+		);
 		constraintViolation = constraintViolations.iterator().next();
 
 		nodeIter = constraintViolation.getPropertyPath().iterator();
@@ -1779,7 +1853,9 @@ public class PropertyPathTest extends AbstractTCKTest {
 	}
 
 	private void checkActorViolations(Set<ConstraintViolation<Actor>> constraintViolations) {
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+		);
 
 		ConstraintViolation<Actor> constraintViolation = constraintViolations.iterator().next();
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/ValidatePropertyTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/ValidatePropertyTest.java
@@ -6,11 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.validation;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertConstraintViolation;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintTypes;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.fail;
@@ -122,23 +120,23 @@ public class ValidatePropertyTest extends AbstractTCKTest {
 		address.setCity( townInNorthWales );
 
 		Set<ConstraintViolation<Address>> constraintViolations = getValidator().validateProperty( address, "city" );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintTypes( constraintViolations, Size.class );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Size.class )
+						.withMessage( "City name cannot be longer than 30 characters." )
+						.withProperty( "city" )
+						.withInvalidValue( townInNorthWales )
+		);
 
 		ConstraintViolation<Address> violation = constraintViolations.iterator().next();
-		assertConstraintViolation( violation, Address.class, townInNorthWales, pathWith().property( "city" ) );
 		assertEquals( violation.getRootBean(), address );
 		assertEquals( violation.getLeafBean(), address );
 		assertEquals( violation.getInvalidValue(), townInNorthWales );
 		assertNull( violation.getExecutableParameters() );
 		assertNull( violation.getExecutableReturnValue() );
-		assertCorrectConstraintViolationMessages(
-				constraintViolations, "City name cannot be longer than 30 characters."
-		);
 
 		address.setCity( "London" );
 		constraintViolations = getValidator().validateProperty( address, "city" );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	@Test
@@ -149,7 +147,7 @@ public class ValidatePropertyTest extends AbstractTCKTest {
 		customer.addOrder( order );
 
 		Set<ConstraintViolation<Customer>> constraintViolations = getValidator().validateProperty( customer, "orders" );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	@Test(expectedExceptions = ValidationException.class)

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/ValidateTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/ValidateTest.java
@@ -8,10 +8,10 @@ package org.hibernate.beanvalidation.tck.tests.validation;
 
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintTypes;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
@@ -32,6 +32,7 @@ import javax.validation.Payload;
 import javax.validation.UnexpectedTypeException;
 import javax.validation.ValidationException;
 import javax.validation.Validator;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 import javax.validation.groups.Default;
@@ -143,15 +144,20 @@ public class ValidateTest extends AbstractTCKTest {
 		Engine engine = new Engine();
 		engine.setSerialNumber( "mail@foobar.com" );
 		Set<ConstraintViolation<Engine>> constraintViolations = validator.validate( engine );
-		assertNumberOfViolations( constraintViolations, 2 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Pattern.class ),
+				violationOf( Pattern.class )
+		);
 
 		engine.setSerialNumber( "ABCDEFGH1234" );
 		constraintViolations = validator.validate( engine );
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Pattern.class )
+		);
 
 		engine.setSerialNumber( "ABCD-EFGH-1234" );
 		constraintViolations = validator.validate( engine );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	@Test
@@ -168,8 +174,10 @@ public class ValidateTest extends AbstractTCKTest {
 		address.setCity( "Llanfairpwllgwyngyllgogerychwyrndrobwyll-llantysiliogogogoch" ); //town in North Wales
 
 		Set<ConstraintViolation<Address>> constraintViolations = validator.validate( address );
-		assertNumberOfViolations( constraintViolations, 2 );
-		assertCorrectConstraintTypes( constraintViolations, Size.class, NotEmpty.class );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Size.class ),
+				violationOf( NotEmpty.class )
+		);
 	}
 
 	@Test
@@ -194,7 +202,9 @@ public class ValidateTest extends AbstractTCKTest {
 		Engine engine = new Engine();
 		engine.setSerialNumber( "ABCDEFGH1234" );
 		Set<ConstraintViolation<Engine>> constraintViolations = validator.validate( engine );
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Pattern.class )
+		);
 
 		ConstraintViolation<Engine> violation = constraintViolations.iterator().next();
 
@@ -216,7 +226,7 @@ public class ValidateTest extends AbstractTCKTest {
 
 		engine.setSerialNumber( "ABCD-EFGH-1234" );
 		constraintViolations = validator.validate( engine );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	@Test
@@ -232,7 +242,9 @@ public class ValidateTest extends AbstractTCKTest {
 
 		DirtBike bike = new DirtBike();
 		Set<ConstraintViolation<DirtBike>> constraintViolations = validator.validate( bike );
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( ValidDirtBike.class )
+		);
 
 		ConstraintViolation<DirtBike> violation = constraintViolations.iterator().next();
 
@@ -271,22 +283,26 @@ public class ValidateTest extends AbstractTCKTest {
 		clint.addPlayedWith( morgan );
 
 		Set<ConstraintViolation<Actor>> constraintViolations = validator.validate( clint );
-		assertNumberOfViolations( constraintViolations, 2 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withMessage( "Everyone has a last name." )
+						.withPropertyPath( pathWith()
+								.property( "playedWith" )
+								.property( "playedWith", true, null, 0, List.class, 0 )
+								.property( "lastName", true, null, 1, List.class, 0 )
+						),
+				violationOf( NotNull.class )
+						.withMessage( "Everyone has a last name." )
+						.withPropertyPath( pathWith()
+								.property( "playedWith" )
+								.property( "lastName", true, null, 1, List.class, 0 )
+						)
+		);
 
 		ConstraintViolation<Actor> constraintViolation = constraintViolations.iterator().next();
-		assertEquals( constraintViolation.getMessage(), "Everyone has a last name.", "Wrong message" );
 		assertEquals( constraintViolation.getRootBean(), clint, "Wrong root entity" );
 		assertEquals( constraintViolation.getLeafBean(), morgan );
 		assertEquals( constraintViolation.getInvalidValue(), morgan.getLastName(), "Wrong value" );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "playedWith" )
-						.property( "playedWith", true, null, 0, List.class, 0 )
-						.property( "lastName", true, null, 1, List.class, 0 ),
-				pathWith()
-						.property( "playedWith" )
-						.property( "lastName", true, null, 1, List.class, 0 )
-		);
 	}
 
 	@Test
@@ -310,20 +326,24 @@ public class ValidateTest extends AbstractTCKTest {
 		clint.addPlayedWith( morgan );
 
 		Set<ConstraintViolation<Actor>> constraintViolations = validator.validate( clint );
-		assertNumberOfViolations( constraintViolations, 2 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withMessage( "Everyone has a last name." )
+						.withPropertyPath( pathWith()
+								.property( "playedWith" )
+								.property( "playedWith", true, null, 0, Object[].class, null )
+								.property( "lastName", true, null, 1, Object[].class, null )
+						),
+				violationOf( NotNull.class )
+						.withMessage( "Everyone has a last name." )
+						.withPropertyPath( pathWith()
+								.property( "playedWith" )
+								.property( "lastName", true, null, 1, Object[].class, null )
+						)
+		);
 		ConstraintViolation<Actor> constraintViolation = constraintViolations.iterator().next();
-		assertEquals( constraintViolation.getMessage(), "Everyone has a last name.", "Wrong message" );
 		assertEquals( constraintViolation.getRootBean(), clint, "Wrong root entity" );
 		assertEquals( constraintViolation.getInvalidValue(), morgan.getLastName(), "Wrong value" );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "playedWith" )
-						.property( "playedWith", true, null, 0, Object[].class, null )
-						.property( "lastName", true, null, 1, Object[].class, null ),
-				pathWith()
-						.property( "playedWith" )
-						.property( "lastName", true, null, 1, Object[].class, null )
-		);
 	}
 
 	@Test
@@ -335,13 +355,15 @@ public class ValidateTest extends AbstractTCKTest {
 		Set<ConstraintViolation<Car>> violations = validator.validateProperty(
 				car, "licensePlateNumber", First.class, Second.class
 		);
-		assertNumberOfViolations( violations, 1 );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Pattern.class )
+		);
 
 		car.setLicensePlateNumber( "USD-298" );
 		violations = validator.validateProperty(
 				car, "licensePlateNumber", First.class, Second.class
 		);
-		assertNumberOfViolations( violations, 0 );
+		assertNoViolations( violations );
 	}
 
 	@Test(expectedExceptions = ValidationException.class)

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/ValidateValueTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/ValidateValueTest.java
@@ -6,12 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.validation;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertConstraintViolation;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
-import static org.testng.Assert.assertEquals;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.fail;
 
@@ -20,6 +17,7 @@ import java.util.Set;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
+import javax.validation.constraints.NotNull;
 
 import org.hibernate.beanvalidation.tck.beanvalidation.Sections;
 import org.hibernate.beanvalidation.tck.tests.AbstractTCKTest;
@@ -60,7 +58,7 @@ public class ValidateValueTest extends AbstractTCKTest {
 		Set<ConstraintViolation<Address>> constraintViolations = validator.validateValue(
 				Address.class, "city", "Paris"
 		);
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	@Test
@@ -71,8 +69,11 @@ public class ValidateValueTest extends AbstractTCKTest {
 		Set<ConstraintViolation<Address>> constraintViolations = validator.validateValue(
 				Address.class, "city", null
 		);
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintViolationMessages( constraintViolations, "You have to specify a city." );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withProperty( "city" )
+						.withMessage( "You have to specify a city." )
+		);
 	}
 
 	@Test
@@ -91,23 +92,22 @@ public class ValidateValueTest extends AbstractTCKTest {
 		Set<ConstraintViolation<Order>> constraintViolations = validator.validateValue(
 				Order.class, "orderNumber", null
 		);
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "orderNumber" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withProperty( "orderNumber" )
+						.withMessage( "An order must have an order number." )
+						.withInvalidValue( null )
+						.withRootBeanClass( Order.class )
 		);
-		assertCorrectConstraintViolationMessages( constraintViolations, "An order must have an order number." );
 
 		ConstraintViolation<Order> constraintViolation = constraintViolations.iterator().next();
-		assertConstraintViolation( constraintViolation, Order.class, null, pathWith().property( "orderNumber" ) );
-		assertEquals( constraintViolation.getRootBeanClass(), Order.class, "Wrong root bean class" );
 		assertNull( constraintViolation.getRootBean() );
 		assertNull( constraintViolation.getLeafBean() );
 		assertNull( constraintViolation.getExecutableParameters() );
 		assertNull( constraintViolation.getExecutableReturnValue() );
 
 		constraintViolations = validator.validateValue( Order.class, "orderNumber", 1234 );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	@Test
@@ -180,6 +180,6 @@ public class ValidateValueTest extends AbstractTCKTest {
 		Set<ConstraintViolation<Customer>> constraintViolations = validator.validateValue(
 				Customer.class, "orders", order
 		);
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 }

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/ValidateWithGroupsTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/ValidateWithGroupsTest.java
@@ -6,10 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.validation;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintTypes;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.util.Set;
 
@@ -53,45 +52,28 @@ public class ValidateWithGroupsTest extends AbstractTCKTest {
 		Validator validator = TestUtil.getValidatorUnderTest();
 
 		Set<ConstraintViolation<Address>> constraintViolations = validator.validate( new Address() );
-		assertNumberOfViolations( constraintViolations, 2 );
-		assertCorrectConstraintTypes( constraintViolations, NotNull.class, NotEmpty.class );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "city" ),
-				pathWith()
-						.property( "zipCode" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withProperty( "city" ),
+				violationOf( NotEmpty.class ).withProperty( "zipCode" )
 		);
 
 		constraintViolations = validator.validate( new Address(), Default.class );
-		assertNumberOfViolations( constraintViolations, 2 );
-		assertCorrectConstraintTypes( constraintViolations, NotNull.class, NotEmpty.class );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "city" ),
-				pathWith()
-						.property( "zipCode" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withProperty( "city" ),
+				violationOf( NotEmpty.class ).withProperty( "zipCode" )
 		);
 
 		constraintViolations = validator.validate( new Address(), Address.Minimal.class );
-		assertNumberOfViolations( constraintViolations, 2 );
-		assertCorrectConstraintTypes( constraintViolations, NotEmpty.class, NotEmpty.class );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "street" ),
-				pathWith()
-						.property( "zipCode" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotEmpty.class ).withProperty( "street" ),
+				violationOf( NotEmpty.class ).withProperty( "zipCode" )
 		);
 
 		constraintViolations = validator.validate( new Address(), Default.class, Address.Minimal.class );
-		assertNumberOfViolations( constraintViolations, 3 );
-		assertCorrectConstraintTypes( constraintViolations, NotNull.class, NotEmpty.class, NotEmpty.class );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "street" ),
-				pathWith()
-						.property( "city" ),
-				pathWith()
-						.property( "zipCode" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withProperty( "city" ),
+				violationOf( NotEmpty.class ).withProperty( "street" ),
+				violationOf( NotEmpty.class ).withProperty( "zipCode" )
 		);
 	}
 
@@ -104,30 +86,21 @@ public class ValidateWithGroupsTest extends AbstractTCKTest {
 		Validator validator = TestUtil.getValidatorUnderTest();
 
 		Set<ConstraintViolation<Address>> constraintViolations = validator.validateProperty( new Address(), "city" );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintTypes( constraintViolations, NotNull.class );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "city" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withProperty( "city" )
 		);
 
 		constraintViolations = validator.validateProperty( new Address(), "city", Default.class );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintTypes( constraintViolations, NotNull.class );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "city" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withProperty( "city" )
 		);
 
 		constraintViolations = validator.validateProperty( new Address(), "city", Address.Minimal.class );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		constraintViolations = validator.validateProperty( new Address(), "street", Address.Minimal.class );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintTypes( constraintViolations, NotEmpty.class );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "street" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotEmpty.class ).withProperty( "street" )
 		);
 	}
 
@@ -140,30 +113,21 @@ public class ValidateWithGroupsTest extends AbstractTCKTest {
 		Validator validator = TestUtil.getValidatorUnderTest();
 
 		Set<ConstraintViolation<Address>> constraintViolations = validator.validateValue( Address.class, "city", null );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintTypes( constraintViolations, NotNull.class );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "city" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withProperty( "city" )
 		);
 
 		constraintViolations = validator.validateValue( Address.class, "city", null, Default.class );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintTypes( constraintViolations, NotNull.class );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "city" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withProperty( "city" )
 		);
 
 		constraintViolations = validator.validateValue( Address.class, "city", null, Address.Minimal.class );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		constraintViolations = validator.validateValue( Address.class, "street", null, Address.Minimal.class );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintTypes( constraintViolations, NotEmpty.class );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "street" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotEmpty.class ).withProperty( "street" )
 		);
 	}
 }

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/graphnavigation/containerelement/NestedCascadingOnContainerElementsTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/graphnavigation/containerelement/NestedCascadingOnContainerElementsTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.beanvalidation.tck.tests.validation.graphnavigation.containerelement;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
@@ -64,7 +64,7 @@ public class NestedCascadingOnContainerElementsTest extends AbstractTCKTest {
 
 		Set<ConstraintViolation<EmailAddressMap>> constraintViolations = validator.validate( EmailAddressMap.validEmailAddressMap() );
 
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		constraintViolations = validator.validate( EmailAddressMap.invalidEmailAddressMap() );
 
@@ -92,7 +92,7 @@ public class NestedCascadingOnContainerElementsTest extends AbstractTCKTest {
 
 		Set<ConstraintViolation<AddressBook>> constraintViolations = validator.validate( AddressBook.valid() );
 
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		constraintViolations = validator.validate( AddressBook.invalid() );
 
@@ -131,7 +131,7 @@ public class NestedCascadingOnContainerElementsTest extends AbstractTCKTest {
 
 		Set<ConstraintViolation<CinemaEmailAddresses>> constraintViolations = validator.validate( CinemaEmailAddresses.validCinemaEmailAddresses() );
 
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		CinemaEmailAddresses invalidCinemaEmailAddresses = CinemaEmailAddresses.invalidCinemaEmailAddresses();
 		constraintViolations = validator.validate( invalidCinemaEmailAddresses );
@@ -185,7 +185,7 @@ public class NestedCascadingOnContainerElementsTest extends AbstractTCKTest {
 		Set<ConstraintViolation<NestedCascadingListWithValidAllAlongTheWay>> constraintViolations = validator
 				.validate( NestedCascadingListWithValidAllAlongTheWay.valid() );
 
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		constraintViolations = validator.validate( NestedCascadingListWithValidAllAlongTheWay.withNullList() );
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/groupconversion/GroupConversionValidationTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/groupconversion/GroupConversionValidationTest.java
@@ -6,9 +6,10 @@
  */
 package org.hibernate.beanvalidation.tck.tests.validation.groupconversion;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 import static org.testng.Assert.assertTrue;
 
 import java.lang.reflect.Constructor;
@@ -154,13 +155,13 @@ public class GroupConversionValidationTest extends AbstractTCKTest {
 				.validateReturnValue( user, method, returnValue );
 
 		//then
-		assertNumberOfViolations( constraintViolations, 1 );
-
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.method( "retrieveMainAddress" )
-						.returnValue()
-						.property( "street1" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+							   .method( "retrieveMainAddress" )
+							   .returnValue()
+							   .property( "street1" )
+						)
 		);
 	}
 
@@ -178,13 +179,13 @@ public class GroupConversionValidationTest extends AbstractTCKTest {
 				.validateReturnValue( user, method, returnValue );
 
 		//then
-		assertNumberOfViolations( constraintViolations, 1 );
-
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.method( "retrieveWeekendAddress" )
-						.returnValue()
-						.property( "street1" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+							   .method( "retrieveWeekendAddress" )
+							   .returnValue()
+							   .property( "street1" )
+						)
 		);
 	}
 
@@ -202,13 +203,13 @@ public class GroupConversionValidationTest extends AbstractTCKTest {
 				.validateReturnValue( user, method, returnValue );
 
 		//then
-		assertNumberOfViolations( constraintViolations, 1 );
-
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.method( "retrieveFallbackAddress" )
-						.returnValue()
-						.property( "street1" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+							   .method( "retrieveFallbackAddress" )
+							   .returnValue()
+							   .property( "street1" )
+						)
 		);
 	}
 
@@ -225,13 +226,13 @@ public class GroupConversionValidationTest extends AbstractTCKTest {
 				.validateParameters( user, method, arguments );
 
 		//then
-		assertNumberOfViolations( constraintViolations, 1 );
-
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.method( "setMainAddress" )
-						.parameter( "mainAddress", 0 )
-						.property( "street1" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+							   .method( "setMainAddress" )
+							   .parameter( "mainAddress", 0 )
+							   .property( "street1" )
+						)
 		);
 	}
 
@@ -247,14 +248,14 @@ public class GroupConversionValidationTest extends AbstractTCKTest {
 				.validateConstructorReturnValue( constructor, createdObject );
 
 		//then
-		assertNumberOfViolations( constraintViolations, 1 );
-
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.constructor( User.class )
-						.returnValue()
-						.property( "mainAddress" )
-						.property( "street1" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+							   .constructor( User.class )
+							   .returnValue()
+							   .property( "mainAddress" )
+							   .property( "street1" )
+						)
 		);
 	}
 
@@ -270,13 +271,13 @@ public class GroupConversionValidationTest extends AbstractTCKTest {
 				.validateConstructorParameters( constructor, arguments );
 
 		//then
-		assertNumberOfViolations( constraintViolations, 1 );
-
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.constructor( User.class )
-						.parameter( "mainAddress", 0 )
-						.property( "street1" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+							   .constructor( User.class )
+							   .parameter( "mainAddress", 0 )
+							   .property( "street1" )
+						)
 		);
 	}
 
@@ -312,7 +313,7 @@ public class GroupConversionValidationTest extends AbstractTCKTest {
 		User user = TestUsers.validUser();
 
 		Set<ConstraintViolation<User>> constraintViolations = getValidator().validate( user );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		user.getWeekendAddress().setDoorCode( "ABC" );
 		constraintViolations = getValidator().validate( user );

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/groupconversion/containerelement/AbstractContainerElementGroupConversionValidationTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/groupconversion/containerelement/AbstractContainerElementGroupConversionValidationTest.java
@@ -6,9 +6,10 @@
  */
 package org.hibernate.beanvalidation.tck.tests.validation.groupconversion.containerelement;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
@@ -20,6 +21,7 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.validation.ConstraintViolation;
+import javax.validation.constraints.NotNull;
 import javax.validation.groups.Default;
 
 import org.hibernate.beanvalidation.tck.beanvalidation.Sections;
@@ -165,14 +167,14 @@ public abstract class AbstractContainerElementGroupConversionValidationTest exte
 				.validateReturnValue( registeredAddresses, method, returnValue );
 
 		//then
-		assertNumberOfViolations( constraintViolations, 1 );
-
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.method( "retrieveMainAddresses" )
-						.returnValue()
-						.containerElement( "<map value>", true, TestRegisteredAddresses.REFERENCE_YEAR, null, Map.class, 1 )
-						.property( "street1", true, null, 0, List.class, 0 )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+							   .method( "retrieveMainAddresses" )
+							   .returnValue()
+							   .containerElement( "<map value>", true, TestRegisteredAddresses.REFERENCE_YEAR, null, Map.class, 1 )
+							   .property( "street1", true, null, 0, List.class, 0 )
+						)
 		);
 	}
 
@@ -191,14 +193,14 @@ public abstract class AbstractContainerElementGroupConversionValidationTest exte
 				.validateParameters( registeredAddresses, method, arguments );
 
 		//then
-		assertNumberOfViolations( constraintViolations, 1 );
-
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.method( "setMainAddresses" )
-						.parameter( "mainAddresses", 0 )
-						.containerElement( "<map value>", true, TestRegisteredAddresses.REFERENCE_YEAR, null, Map.class, 1 )
-						.property( "street1", true, null, 0, List.class, 0 )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+							   .method( "setMainAddresses" )
+							   .parameter( "mainAddresses", 0 )
+							   .containerElement( "<map value>", true, TestRegisteredAddresses.REFERENCE_YEAR, null, Map.class, 1 )
+							   .property( "street1", true, null, 0, List.class, 0 )
+						)
 		);
 	}
 
@@ -216,15 +218,15 @@ public abstract class AbstractContainerElementGroupConversionValidationTest exte
 				.validateConstructorReturnValue( constructor, createdObject );
 
 		//then
-		assertNumberOfViolations( constraintViolations, 1 );
-
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.constructor( RegisteredAddresses.class )
-						.returnValue()
-						.property( "mainAddresses" )
-						.containerElement( "<map value>", true, TestRegisteredAddresses.REFERENCE_YEAR, null, Map.class, 1 )
-						.property( "street1", true, null, 1, List.class, 0 )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+							   .constructor( RegisteredAddresses.class )
+							   .returnValue()
+							   .property( "mainAddresses" )
+							   .containerElement( "<map value>", true, TestRegisteredAddresses.REFERENCE_YEAR, null, Map.class, 1 )
+							   .property( "street1", true, null, 1, List.class, 0 )
+						)
 		);
 	}
 
@@ -242,14 +244,14 @@ public abstract class AbstractContainerElementGroupConversionValidationTest exte
 				.validateConstructorParameters( constructor, arguments );
 
 		//then
-		assertNumberOfViolations( constraintViolations, 1 );
-
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.constructor( RegisteredAddresses.class )
-						.parameter( "mainAddresses", 0 )
-						.containerElement( "<map value>", true, TestRegisteredAddresses.REFERENCE_YEAR, null, Map.class, 1 )
-						.property( "street1", true, null, 0, List.class, 0 )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+				.withPropertyPath( pathWith()
+					   .constructor( RegisteredAddresses.class )
+					   .parameter( "mainAddresses", 0 )
+					   .containerElement( "<map value>", true, TestRegisteredAddresses.REFERENCE_YEAR, null, Map.class, 1 )
+					   .property( "street1", true, null, 0, List.class, 0 )
+				)
 		);
 	}
 
@@ -292,7 +294,7 @@ public abstract class AbstractContainerElementGroupConversionValidationTest exte
 		RegisteredAddresses registeredAddresses = TestRegisteredAddresses.validRegisteredAddresses();
 
 		Set<ConstraintViolation<RegisteredAddresses>> constraintViolations = getValidator().validate( registeredAddresses );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		registeredAddresses.getWeekendAddresses().get( TestRegisteredAddresses.REFERENCE_YEAR ).get( 0 ).setDoorCode( "ABC" );
 		constraintViolations = getValidator().validate( registeredAddresses );

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/validatorcontext/ConstraintValidatorContextTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/validation/validatorcontext/ConstraintValidatorContextTest.java
@@ -6,11 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.validation.validatorcontext;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintTypes;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -65,8 +63,9 @@ public class ConstraintValidatorContextTest extends AbstractTCKTest {
 		DummyBean bean = new DummyBean( "foobar" );
 
 		Set<ConstraintViolation<DummyBean>> constraintViolations = validator.validate( bean );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintViolationMessages( constraintViolations, "dummy message" );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Dummy.class ).withMessage( "dummy message" )
+		);
 	}
 
 	@Test(expectedExceptions = ValidationException.class)
@@ -97,11 +96,10 @@ public class ConstraintValidatorContextTest extends AbstractTCKTest {
 		DummyBean bean = new DummyBean( "foobar" );
 
 		Set<ConstraintViolation<DummyBean>> constraintViolations = validator.validate( bean );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintViolationMessages( constraintViolations, "message1" );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "value" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Dummy.class )
+						.withMessage( "message1" )
+						.withProperty( "value" )
 		);
 	}
 
@@ -121,12 +119,13 @@ public class ConstraintValidatorContextTest extends AbstractTCKTest {
 		DummyBean bean = new DummyBean( "foobar" );
 
 		Set<ConstraintViolation<DummyBean>> constraintViolations = validator.validate( bean );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintViolationMessages( constraintViolations, "subnode message" );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "value" )
-						.property( "subnode" )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Dummy.class )
+						.withMessage( "subnode message" )
+						.withPropertyPath( pathWith()
+							   .property( "value" )
+							   .property( "subnode" )
+						)
 		);
 	}
 
@@ -140,13 +139,13 @@ public class ConstraintValidatorContextTest extends AbstractTCKTest {
 		Group group = new Group( Gender.MALE, new Person( Gender.FEMALE ) );
 
 		Set<ConstraintViolation<Group>> constraintViolations = validator.validate( group );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertThat( constraintViolations ).containsOnlyPaths(
-				pathWith()
-						.property( "persons" )
-						.property( null, true, null, 0 )
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( CompatiblePersons.class )
+						.withPropertyPath( pathWith()
+							   .property( "persons" )
+							   .property( null, true, null, 0 )
+						)
 		);
-		assertCorrectConstraintTypes( constraintViolations, CompatiblePersons.class );
 	}
 
 	private enum Gender {

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/builtin/JavaFXValueExtractorsTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/builtin/JavaFXValueExtractorsTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.beanvalidation.tck.tests.valueextraction.builtin;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.pathWith;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
@@ -87,7 +87,7 @@ public class JavaFXValueExtractorsTest extends AbstractTCKTest {
 		Validator validator = getValidator();
 
 		Set<ConstraintViolation<ListPropertyEntity>> constraintViolations = validator.validate( ListPropertyEntity.valid() );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		constraintViolations = validator.validate( ListPropertyEntity.invalidList() );
 		assertThat( constraintViolations ).containsOnlyViolations(
@@ -109,7 +109,7 @@ public class JavaFXValueExtractorsTest extends AbstractTCKTest {
 		Validator validator = getValidator();
 
 		Set<ConstraintViolation<SetPropertyEntity>> constraintViolations = validator.validate( SetPropertyEntity.valid() );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		constraintViolations = validator.validate( SetPropertyEntity.invalidSet() );
 		assertThat( constraintViolations ).containsOnlyViolations(
@@ -131,7 +131,7 @@ public class JavaFXValueExtractorsTest extends AbstractTCKTest {
 		Validator validator = getValidator();
 
 		Set<ConstraintViolation<MapPropertyEntity>> constraintViolations = validator.validate( MapPropertyEntity.valid() );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		constraintViolations = validator.validate( MapPropertyEntity.invalidMap() );
 		assertThat( constraintViolations ).containsOnlyViolations(
@@ -163,7 +163,7 @@ public class JavaFXValueExtractorsTest extends AbstractTCKTest {
 		Validator validator = getValidator();
 
 		Set<ConstraintViolation<ListOfStringPropertyEntity>> constraintViolations = validator.validate( ListOfStringPropertyEntity.valid() );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 
 		constraintViolations = validator.validate( ListOfStringPropertyEntity.invalidListElement() );
 		assertThat( constraintViolations ).containsOnlyViolations(

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/builtin/OptionalValueExtractorTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/builtin/OptionalValueExtractorTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.beanvalidation.tck.tests.valueextraction.builtin;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
 import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
@@ -50,7 +50,7 @@ public class OptionalValueExtractorTest extends AbstractTCKTest {
 		Validator validator = getValidator();
 
 		Set<ConstraintViolation<OptionalHolder>> violations = validator.validate( new OptionalHolder( Optional.of( "valid" ) ) );
-		assertNumberOfViolations( violations, 0 );
+		assertNoViolations( violations );
 
 		violations = validator.validate( new OptionalHolder( Optional.of( "" ) ) );
 		assertThat( violations ).containsOnlyViolations(
@@ -70,7 +70,7 @@ public class OptionalValueExtractorTest extends AbstractTCKTest {
 		Validator validator = getValidator();
 
 		Set<ConstraintViolation<OptionalIntHolder>> violations = validator.validate( new OptionalIntHolder( OptionalInt.of( 10 ) ) );
-		assertNumberOfViolations( violations, 0 );
+		assertNoViolations( violations );
 
 		violations = validator.validate( new OptionalIntHolder( OptionalInt.of( 3 ) ) );
 		assertThat( violations ).containsOnlyViolations(
@@ -89,7 +89,7 @@ public class OptionalValueExtractorTest extends AbstractTCKTest {
 		Validator validator = getValidator();
 
 		Set<ConstraintViolation<OptionalLongHolder>> violations = validator.validate( new OptionalLongHolder( OptionalLong.of( 10 ) ) );
-		assertNumberOfViolations( violations, 0 );
+		assertNoViolations( violations );
 
 		violations = validator.validate( new OptionalLongHolder( OptionalLong.of( 3 ) ) );
 		assertThat( violations ).containsOnlyViolations(
@@ -108,7 +108,7 @@ public class OptionalValueExtractorTest extends AbstractTCKTest {
 		Validator validator = getValidator();
 
 		Set<ConstraintViolation<OptionalDoubleHolder>> violations = validator.validate( new OptionalDoubleHolder( OptionalDouble.of( 10 ) ) );
-		assertNumberOfViolations( violations, 0 );
+		assertNoViolations( violations );
 
 		violations = validator.validate( new OptionalDoubleHolder( OptionalDouble.of( 3 ) ) );
 		assertThat( violations ).containsOnlyViolations(

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/ClockProviderSpecifiedInValidationXmlTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/ClockProviderSpecifiedInValidationXmlTest.java
@@ -6,7 +6,8 @@
  */
 package org.hibernate.beanvalidation.tck.tests.xmlconfiguration;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintTypes;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 import static org.testng.Assert.assertTrue;
 
 import java.time.Clock;
@@ -74,7 +75,9 @@ public class ClockProviderSpecifiedInValidationXmlTest extends AbstractTCKTest {
 		User user = new User();
 		user.setBirthday( ZonedDateTime.of( 1980, 11, 10, 9, 16, 0, 0, ZoneId.of( "Europe/Paris" ) ) );
 		Set<ConstraintViolation<User>> constraintViolations = validator.validate( user );
-		assertCorrectConstraintTypes( constraintViolations, Past.class );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Past.class )
+		);
 	}
 
 	private static class ConfigurationDefinedClockProvider implements ClockProvider {

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/MessageInterpolatorSpecifiedInValidationXmlTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/MessageInterpolatorSpecifiedInValidationXmlTest.java
@@ -6,8 +6,8 @@
  */
 package org.hibernate.beanvalidation.tck.tests.xmlconfiguration;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.util.Set;
 
@@ -15,6 +15,7 @@ import javax.validation.Configuration;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.Validator;
+import javax.validation.constraints.NotNull;
 
 import org.hibernate.beanvalidation.tck.beanvalidation.Sections;
 import org.hibernate.beanvalidation.tck.tests.AbstractTCKTest;
@@ -54,9 +55,8 @@ public class MessageInterpolatorSpecifiedInValidationXmlTest extends AbstractTCK
 
 		User user = new User();
 		Set<ConstraintViolation<User>> constraintViolations = validator.validate( user );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintViolationMessages(
-				constraintViolations, XmlDefinedMessageInterpolator.STATIC_INTERPOLATION_STRING
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withMessage( XmlDefinedMessageInterpolator.STATIC_INTERPOLATION_STRING )
 		);
 	}
 
@@ -74,9 +74,8 @@ public class MessageInterpolatorSpecifiedInValidationXmlTest extends AbstractTCK
 
 		User user = new User();
 		Set<ConstraintViolation<User>> constraintViolations = validator.validate( user );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintViolationMessages(
-				constraintViolations, ConfigurationDefinedMessageInterpolator.STATIC_INTERPOLATION_STRING
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withMessage( ConfigurationDefinedMessageInterpolator.STATIC_INTERPOLATION_STRING )
 		);
 	}
 }

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/OptionalValidationXmlTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/OptionalValidationXmlTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.beanvalidation.tck.tests.xmlconfiguration;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
 
 import java.util.Set;
 
@@ -46,6 +46,6 @@ public class OptionalValidationXmlTest extends AbstractTCKTest {
 
 		Order order = new Order();
 		Set<ConstraintViolation<Order>> constraintViolations = validator.validate( order );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 }

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/TraversableResolverSpecifiedInValidationXmlTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/TraversableResolverSpecifiedInValidationXmlTest.java
@@ -6,7 +6,8 @@
  */
 package org.hibernate.beanvalidation.tck.tests.xmlconfiguration;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 import static org.testng.Assert.assertTrue;
 
 import java.util.Set;
@@ -15,6 +16,7 @@ import javax.validation.Configuration;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.Validator;
+import javax.validation.constraints.NotNull;
 
 import org.hibernate.beanvalidation.tck.beanvalidation.Sections;
 import org.hibernate.beanvalidation.tck.tests.AbstractTCKTest;
@@ -54,7 +56,9 @@ public class TraversableResolverSpecifiedInValidationXmlTest extends AbstractTCK
 
 		User user = new User();
 		Set<ConstraintViolation<User>> constraintViolations = validator.validate( user );
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+		);
 		assertTrue(
 				XmlDefinedTraversableResolver.numberOfIsReachableCalls > 0,
 				"The resolver should have been called at least once if it was properly picked up by xml configuration."
@@ -77,7 +81,9 @@ public class TraversableResolverSpecifiedInValidationXmlTest extends AbstractTCK
 
 		User user = new User();
 		Set<ConstraintViolation<User>> constraintViolations = validator.validate( user );
-		assertNumberOfViolations( constraintViolations, 1 );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+		);
 		assertTrue(
 				ConfigurationDefinedTraversableResolver.numberOfIsReachableCalls > 0,
 				"The resolver should have been called at least once if configuration settings were applied."

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/XmlConfigurationTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/XmlConfigurationTest.java
@@ -6,8 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.xmlconfiguration;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNoViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -20,6 +21,8 @@ import javax.validation.ConstraintViolation;
 import javax.validation.Payload;
 import javax.validation.ValidationException;
 import javax.validation.Validator;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
 import javax.validation.metadata.BeanDescriptor;
 import javax.validation.metadata.ConstraintDescriptor;
 
@@ -77,9 +80,8 @@ public class XmlConfigurationTest extends AbstractTCKTest {
 	public void testClassConstraintDefinedInXml() {
 		User user = new User();
 		Set<ConstraintViolation<User>> constraintViolations = getValidator().validate( user, TestGroup.class );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintViolationMessages(
-				constraintViolations, "Message from xml"
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( ConsistentUserInformation.class ).withMessage( "Message from xml" )
 		);
 
 		ConstraintViolation<User> constraintViolation = constraintViolations.iterator().next();
@@ -89,7 +91,7 @@ public class XmlConfigurationTest extends AbstractTCKTest {
 
 		user.setConsistent( true );
 		constraintViolations = getValidator().validate( user );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	@Test
@@ -103,11 +105,12 @@ public class XmlConfigurationTest extends AbstractTCKTest {
 	})
 	public void testIgnoreValidationXml() {
 		Configuration<?> config = TestUtil.getConfigurationUnderTest();
+		//TODO: is this needed? this validator is not used later.
 		Validator validator = config.ignoreXmlConfiguration().buildValidatorFactory().getValidator();
 
 		Order order = new Order();
 		Set<ConstraintViolation<Order>> constraintViolations = getValidator().validate( order );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	@Test
@@ -125,12 +128,13 @@ public class XmlConfigurationTest extends AbstractTCKTest {
 		user.setFirstname( "Wolfeschlegelsteinhausenbergerdorff" );
 
 		Set<ConstraintViolation<User>> constraintViolations = getValidator().validate( user );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintViolationMessages( constraintViolations, "Size is limited!" );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Size.class ).withMessage( "Size is limited!" )
+		);
 
 		user.setFirstname( "Wolfgang" );
 		constraintViolations = getValidator().validate( user );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	@Test
@@ -149,14 +153,13 @@ public class XmlConfigurationTest extends AbstractTCKTest {
 		user.setLastname( "doe" );
 
 		Set<ConstraintViolation<User>> constraintViolations = getValidator().validate( user );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintViolationMessages(
-				constraintViolations, "Last name has to start with with a capital letter."
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Pattern.class ).withMessage( "Last name has to start with with a capital letter." )
 		);
 
 		user.setLastname( "Doe" );
 		constraintViolations = getValidator().validate( user );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	@Test
@@ -174,14 +177,13 @@ public class XmlConfigurationTest extends AbstractTCKTest {
 		user.setPhoneNumber( "police" );
 
 		Set<ConstraintViolation<User>> constraintViolations = getValidator().validate( user );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintViolationMessages(
-				constraintViolations, "A phone number can only contain numbers, whitespaces and dashes."
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Pattern.class ).withMessage( "A phone number can only contain numbers, whitespaces and dashes." )
 		);
 
 		user.setPhoneNumber( "112" );
 		constraintViolations = getValidator().validate( user );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	@Test
@@ -201,12 +203,13 @@ public class XmlConfigurationTest extends AbstractTCKTest {
 		user.setCreditcard( card );
 
 		Set<ConstraintViolation<User>> constraintViolations = getValidator().validate( user );
-		assertNumberOfViolations( constraintViolations, 1 );
-		assertCorrectConstraintViolationMessages( constraintViolations, "Not a credit card number." );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Pattern.class ).withMessage( "Not a credit card number." )
+		);
 
 		card.setNumber( "1234567890" );
 		constraintViolations = getValidator().validate( user );
-		assertNumberOfViolations( constraintViolations, 0 );
+		assertNoViolations( constraintViolations );
 	}
 
 	@Test

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/ConfigurationViaXmlAndAnnotationsTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/ConfigurationViaXmlAndAnnotationsTest.java
@@ -6,8 +6,8 @@
  */
 package org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -83,7 +83,8 @@ public class ConfigurationViaXmlAndAnnotationsTest extends AbstractTCKTest {
 		p.setMaxWeight( 30 );
 		Set<ConstraintViolation<Package>> violations = validator.validate( p, Default.class );
 
-		assertNumberOfViolations( violations, 1 );
-		assertCorrectConstraintViolationMessages( violations, "ValidPackage defined as annotation" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( ValidPackage.class ).withMessage( "ValidPackage defined as annotation" )
+		);
 	}
 }

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/DefaultSequenceDefinedInXmlTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/DefaultSequenceDefinedInXmlTest.java
@@ -6,13 +6,15 @@
  */
 package org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.util.Set;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
+import javax.validation.constraints.Max;
 import javax.validation.groups.Default;
 
 import org.hibernate.beanvalidation.tck.beanvalidation.Sections;
@@ -48,7 +50,8 @@ public class DefaultSequenceDefinedInXmlTest extends AbstractTCKTest {
 		p.setMaxWeight( 30 );
 		Set<ConstraintViolation<Package>> violations = validator.validate( p, Default.class );
 
-		assertNumberOfViolations( violations, 1 );
-		assertCorrectConstraintViolationMessages( violations, "The package is too heavy" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Max.class ).withMessage( "The package is too heavy" )
+		);
 	}
 }

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/clazzlevel/ClassLevelOverridingTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/clazzlevel/ClassLevelOverridingTest.java
@@ -6,8 +6,9 @@
  */
 package org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.clazzlevel;
 
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
-import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertNumberOfViolations;
+
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.assertThat;
+import static org.hibernate.beanvalidation.tck.util.ConstraintViolationAssert.violationOf;
 
 import java.util.Set;
 
@@ -56,8 +57,9 @@ public class ClassLevelOverridingTest extends AbstractTCKTest {
 		Package p = new Package();
 		Set<ConstraintViolation<Package>> violations = validator.validate( p );
 
-		assertNumberOfViolations( violations, 1 );
-		assertCorrectConstraintViolationMessages( violations, "ValidPackage defined in XML" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( ValidPackage.class ).withMessage( "ValidPackage defined in XML" )
+		);
 	}
 
 	@Test
@@ -70,8 +72,9 @@ public class ClassLevelOverridingTest extends AbstractTCKTest {
 		Package p = new Package();
 		Set<ConstraintViolation<Package>> violations = validator.validate( p );
 
-		assertNumberOfViolations( violations, 1 );
-		assertCorrectConstraintViolationMessages( violations, "ValidPackage defined in XML" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( ValidPackage.class ).withMessage( "ValidPackage defined in XML" )
+		);
 	}
 
 	@Test
@@ -85,9 +88,9 @@ public class ClassLevelOverridingTest extends AbstractTCKTest {
 		Package p = new Package();
 		Set<ConstraintViolation<Package>> violations = validator.validate( p );
 
-		assertNumberOfViolations( violations, 2 );
-		assertCorrectConstraintViolationMessages(
-				violations, "ValidPackage defined in XML", "ValidPackage defined as annotation"
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( ValidPackage.class ).withMessage( "ValidPackage defined in XML" ),
+				violationOf( ValidPackage.class ).withMessage( "ValidPackage defined as annotation" )
 		);
 	}
 }

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/util/ConstraintViolationAssert.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/util/ConstraintViolationAssert.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Set;
 
 import javax.validation.ConstraintViolation;
-import javax.validation.ConstraintViolationException;
 import javax.validation.ElementKind;
 import javax.validation.Path;
 
@@ -52,44 +51,6 @@ public final class ConstraintViolationAssert {
 	 * Private constructor in order to avoid instantiation.
 	 */
 	private ConstraintViolationAssert() {
-	}
-
-	/**
-	 * Asserts that the messages in the violation list matches exactly the expected messages list.
-	 *
-	 * @param violations The violation list to verify.
-	 * @param expectedMessages The expected constraint violation messages.
-	 */
-	public static void assertCorrectConstraintViolationMessages(Set<? extends ConstraintViolation<?>> violations,
-			String... expectedMessages) {
-		List<String> actualMessages = new ArrayList<>();
-		for ( ConstraintViolation<?> violation : violations ) {
-			actualMessages.add( violation.getMessage() );
-		}
-
-		Assertions.assertThat( actualMessages ).containsExactlyInAnyOrder( expectedMessages );
-	}
-
-	public static void assertCorrectConstraintViolationMessages(ConstraintViolationException e,
-			String... expectedMessages) {
-		assertCorrectConstraintViolationMessages( e.getConstraintViolations(), expectedMessages );
-	}
-
-	/**
-	 * Asserts that the violated constraint type in the violation list matches exactly the expected constraint types
-	 * list.
-	 *
-	 * @param violations The violation list to verify.
-	 * @param expectedConstraintTypes The expected constraint types.
-	 */
-	public static void assertCorrectConstraintTypes(Set<? extends ConstraintViolation<?>> violations,
-			Class<?>... expectedConstraintTypes) {
-		List<Class<? extends Annotation>> actualConstraintTypes = new ArrayList<>();
-		for ( ConstraintViolation<?> violation : violations ) {
-			actualConstraintTypes.add( violation.getConstraintDescriptor().getAnnotation().annotationType() );
-		}
-
-		assertCorrectConstraintTypes( actualConstraintTypes, expectedConstraintTypes );
 	}
 
 	public static ConstraintViolationSetAssert assertThat(Set<? extends ConstraintViolation<?>> actualViolations) {
@@ -135,18 +96,12 @@ public final class ConstraintViolationAssert {
 	}
 
 	/**
-	 * Asserts that the given violation list has the expected number of violations.
+	 * Asserts that the given violation list has no violations (is empty).
 	 *
 	 * @param violations The violation list to verify.
-	 * @param numberOfViolations The expected number of violation.
 	 */
-	public static void assertNumberOfViolations(Set<? extends ConstraintViolation<?>> violations,
-			int numberOfViolations) {
-		assertEquals(
-				violations.size(),
-				numberOfViolations,
-				"Wrong number of constraint violations"
-		);
+	public static void assertNoViolations(Set<? extends ConstraintViolation<?>> violations) {
+		Assertions.assertThat( violations ).isEmpty();
 	}
 
 	/**


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/BVTCK-178

Same thing as for HV tests - replaced usage of some methods with 
```java
assertThat( constraintViolations ).containsOnlyViolations(
	violationOf( SomeConstraint.class )
....
);
```
I also have run HV build against this updated TCK version - all tests passed.

