### PR TITLE
Fix value extractor parallel hierarchies test

### DIFF
--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/resolution/CascadingValueExtactorResolutionAlgorithmTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/resolution/CascadingValueExtactorResolutionAlgorithmTest.java
@@ -24,6 +24,7 @@ import org.hibernate.beanvalidation.tck.tests.valueextraction.resolution.model.C
 import org.hibernate.beanvalidation.tck.tests.valueextraction.resolution.model.CascadingEntity2;
 import org.hibernate.beanvalidation.tck.tests.valueextraction.resolution.model.IWrapper11;
 import org.hibernate.beanvalidation.tck.tests.valueextraction.resolution.model.IWrapper111;
+import org.hibernate.beanvalidation.tck.tests.valueextraction.resolution.model.IWrapper21;
 import org.hibernate.beanvalidation.tck.tests.valueextraction.resolution.model.IWrapper211;
 import org.hibernate.beanvalidation.tck.tests.valueextraction.resolution.model.IWrapper212;
 import org.hibernate.beanvalidation.tck.tests.valueextraction.resolution.model.Wrapper2;
@@ -116,10 +117,10 @@ public class CascadingValueExtactorResolutionAlgorithmTest extends AbstractTCKTe
 		assertThat( violations ).containsOnlyPaths(
 				pathWith()
 						.property( "wrapper" )
-						.property( "property", false, null, null, IWrapper212.class, 0 ),
+						.property( "property", false, null, null, IWrapper21.class, 0 ),
 				pathWith()
 						.property( "wrapper" )
-						.property( "property", false, null, null, IWrapper212.class, 1 )
+						.property( "property", false, null, null, IWrapper21.class, 1 )
 		);
 	}
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/resolution/CascadingValueExtractorResolutionAlgorithmTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/resolution/CascadingValueExtractorResolutionAlgorithmTest.java
@@ -38,12 +38,12 @@ import org.testng.annotations.Test;
  * @author Guillaume Smet
  */
 @SpecVersion(spec = "beanvalidation", version = "2.0.0")
-public class CascadingValueExtactorResolutionAlgorithmTest extends AbstractTCKTest {
+public class CascadingValueExtractorResolutionAlgorithmTest extends AbstractTCKTest {
 
 	@Deployment
 	public static WebArchive createTestArchive() {
 		return webArchiveBuilder()
-				.withTestClass( CascadingValueExtactorResolutionAlgorithmTest.class )
+				.withTestClass( CascadingValueExtractorResolutionAlgorithmTest.class )
 				.withPackage( IWrapper11.class.getPackage() )
 				.build();
 	}

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/resolution/ContainerElementValueExtractorResolutionAlgorithmTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/resolution/ContainerElementValueExtractorResolutionAlgorithmTest.java
@@ -42,12 +42,12 @@ import org.testng.annotations.Test;
  * @author Guillaume Smet
  */
 @SpecVersion(spec = "beanvalidation", version = "2.0.0")
-public class ContainerElementValueExtactorResolutionAlgorithmTest extends AbstractTCKTest {
+public class ContainerElementValueExtractorResolutionAlgorithmTest extends AbstractTCKTest {
 
 	@Deployment
 	public static WebArchive createTestArchive() {
 		return webArchiveBuilder()
-				.withTestClass( ContainerElementValueExtactorResolutionAlgorithmTest.class )
+				.withTestClass( ContainerElementValueExtractorResolutionAlgorithmTest.class )
 				.withPackage( IWrapper11.class.getPackage() )
 				.build();
 	}

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/resolution/model/CascadingEntity2.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/valueextraction/resolution/model/CascadingEntity2.java
@@ -15,7 +15,7 @@ import javax.validation.constraints.NotNull;
 public class CascadingEntity2 {
 
 	@SuppressWarnings("unused")
-	private IWrapper212<@Valid Bean21, @Valid Bean22> wrapper;
+	private IWrapper21<@Valid Bean21, @Valid Bean22> wrapper;
 
 	public CascadingEntity2(String value) {
 		this.wrapper = new Wrapper2<Bean21, Bean22>( new Bean21( value ), new Bean22( value ) );


### PR DESCRIPTION
For discussion, I'll open a proper JIRA once we agree on how to follow up on this.

Basically, with https://github.com/hibernate/hibernate-validator/pull/814 applied, `CascadingValueExtactorResolutionAlgorithmTest#parallelValueExtractorDefinitionsCausesException()` fails as it doesn't throw an exception anymore.

The issue lies in `CascadingEntity2`:
```
private IWrapper212<@Valid Bean21, @Valid Bean22> wrapper;
```

`wrapper` will be a `Wrapper2` so if we only consider the runtime type, `IWrapper211ValueExtractor0` and `IWrapper212ValueExtractor0` will be considered as valid and thus an exception will be thrown. This is how HV behaved before the PR mentioned above.

I think it's an error in the TCK as `IWrapper211ValueExtractor0` is not container element compliant with `IWrapper212` so it shouldn't be considered.

The idea is to change `CascadingEntity2` to:
```
private IWrapper21<@Valid Bean21, @Valid Bean22> wrapper;
```

Then `IWrapper211ValueExtractor0` and `IWrapper212ValueExtractor0` will both be type compliant and container element compliant and thus we will have the exception.

Btw, I spotted a typo in the test names so I also fixed that.