### PR TITLE
BVTCK-193 Exclude the Maven wrapper directory from the license check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,6 +265,7 @@
                         <exclude>**/*.html</exclude>
                         <exclude>**/*.sh</exclude>
                         <exclude>beanvalidation-release-scripts/**</exclude>
+                        <exclude>.mvn/**</exclude>
                     </excludes>
                 </configuration>
                 <executions>


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/BVTCK-193

IMPORTANT: this PR is to be applied to the 2.0 branch.